### PR TITLE
ADDED: caching for create vault form

### DIFF
--- a/src/utils/vaultFormCache.js
+++ b/src/utils/vaultFormCache.js
@@ -1,0 +1,38 @@
+const CACHE_KEY = 'lava_vault_form_cache';
+
+export const saveVaultFormCache = (formData) => {
+  localStorage.setItem(CACHE_KEY, JSON.stringify(formData));
+};
+
+export const loadVaultFormCache = () => {
+  try {
+    const cachedData = localStorage.getItem(CACHE_KEY);
+    if (!cachedData) return null;
+
+    return JSON.parse(cachedData);
+  } catch (error) {
+    clearVaultFormCache();
+    return null;
+  }
+};
+
+export const clearVaultFormCache = () => {
+  localStorage.removeItem(CACHE_KEY);
+};
+
+export const hasVaultFormCache = () => {
+  try {
+    const cachedData = localStorage.getItem(CACHE_KEY);
+    return cachedData !== null;
+  } catch (error) {
+    return false;
+  }
+};
+
+let saveTimeout;
+export const debouncedSaveVaultFormCache = (formData, delay = 1000) => {
+  clearTimeout(saveTimeout);
+  saveTimeout = setTimeout(() => {
+    saveVaultFormCache(formData);
+  }, delay);
+};


### PR DESCRIPTION
This pull request adds persistent caching for the vault creation form, allowing users to recover their progress if they leave and return to the form. The main changes introduce a utility module for caching form data in `localStorage` and integrate it into the `CreateVaultForm` component to automatically save, load, and clear form state.

**Vault form caching functionality:**

* Added a new utility module `vaultFormCache.js` that provides methods to save, load, clear, and debounce saving of vault form data to `localStorage`.
* Integrated the caching utilities into `CreateVaultForm.jsx` by importing the new functions.

**Form state management improvements:**

* Modified the form initialization to load cached form data if available when no vault is provided, allowing users to resume incomplete forms.
* Added an effect to automatically (debounced) save form data to cache whenever the form changes, except when a vault is loaded or the form is in its initial state.
* Ensured that the cache is cleared when a vault is successfully created, preventing stale data from persisting.