### PR TITLE
FIXED: delete local vault creation state

### DIFF
--- a/src/hooks/useAxiosInterceptor.js
+++ b/src/hooks/useAxiosInterceptor.js
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
 
+import { clearAuthLocalStorage } from '@/lib/auth/auth';
 import { axiosInstance } from '@/services/api';
 
 export const useAuthInterceptor = function () {
@@ -13,7 +14,7 @@ export const useAuthInterceptor = function () {
       },
       function (error) {
         if (error.response?.status === 401) {
-          localStorage.removeItem('jwt');
+          clearAuthLocalStorage();
           disconnect();
           window.location.href = '/';
         }

--- a/src/lib/auth/auth.context.jsx
+++ b/src/lib/auth/auth.context.jsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import toast from 'react-hot-toast';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { AuthContext } from '@/lib/auth/auth';
+import { AuthContext, clearAuthLocalStorage } from '@/lib/auth/auth';
 import { useProfile, useLogin } from '@/services/api/queries';
 
 export const AuthProvider = ({ children }) => {
@@ -34,9 +34,7 @@ export const AuthProvider = ({ children }) => {
   };
 
   const logout = message => {
-    localStorage.removeItem('jwt');
-    localStorage.removeItem('authenticated_stake_address');
-    localStorage.removeItem('vlrm_balance_cache');
+    clearAuthLocalStorage();
     queryClient.setQueryData(['profile'], null);
     if (message) {
       sessionStorage.setItem('logout_toast', message);

--- a/src/lib/auth/auth.js
+++ b/src/lib/auth/auth.js
@@ -1,5 +1,13 @@
 import { createContext, useContext } from 'react';
 
+/** LocalStorage keys cleared on logout and on 401 (same set as end of session). */
+export function clearAuthLocalStorage() {
+  localStorage.removeItem('jwt');
+  localStorage.removeItem('authenticated_stake_address');
+  localStorage.removeItem('vlrm_balance_cache');
+  localStorage.removeItem('storageVault');
+}
+
 export const AuthContext = createContext(null);
 
 export const useAuth = () => {


### PR DESCRIPTION
This pull request enhances the application's logout and authentication error handling by ensuring that the `storageVault` item is also removed from local storage when a user logs out or when a 401 (Unauthorized) error occurs. This helps prevent stale or sensitive data from persisting after a user's session ends.

Improvements to session and storage management:

* Added removal of `storageVault` from local storage on 401 errors in the `useAuthInterceptor` hook to ensure sensitive data is cleared when authentication fails.
* Ensured `storageVault` is also removed from local storage during the logout process in the `AuthProvider` context for consistent session cleanup.