### PR TITLE
FIXED: contribution progress counter

### DIFF
--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -67,7 +67,7 @@ export const VaultContribution = ({ vault }) => {
     const displayValue = formatNumber(value);
     return (
       <div
-        className="absolute -top-7.5 flex flex-col items-center z-50"
+        className="absolute -top-7.5 flex flex-col items-center z-10"
         style={{ left: `${Math.min(progress, 100)}%`, transform: 'translateX(-50%)' }}
       >
         <div className="flex px-2 py-1 bg-steel-850 border border-steel-750 rounded-md shadow-lg mb-1">


### PR DESCRIPTION
This pull request makes a minor adjustment to the `VaultContribution` component by changing the z-index of the contribution display element. This will affect how the element is layered relative to other elements on the page.

- Lowered the z-index of the contribution display from `z-50` to `z-10` in the `VaultContribution` component to adjust its stacking context.