### PR TITLE
FIXED: partner code for swap

### DIFF
--- a/src/components/swap/Swap.tsx
+++ b/src/components/swap/Swap.tsx
@@ -10,8 +10,6 @@ import dexhunterStyles from '@dexhunterio/swaps/lib/assets/style.css?inline';
 import { SwapErrorBoundary } from '@/components/swap/SwapErrorBoundary.tsx';
 
 export interface SwapComponentProps {
-  partnerName?: string;
-  partnerCode?: string;
   config?: {
     defaultToken?: string;
     width?: string;
@@ -92,11 +90,8 @@ const RESPONSIVE_OVERRIDE = `
   }
 `;
 
-export const SwapComponent: React.FC<SwapComponentProps> = ({ partnerName = 'l4va', partnerCode, config }) => {
-  const resolvedPartnerCode = useMemo(
-    () => partnerCode || import.meta.env.VITE_DEXHUNTER_PARTNER_CODE || 'l4va_test',
-    [partnerCode]
-  );
+export const SwapComponent: React.FC<SwapComponentProps> = ({ config }) => {
+  const partnerCode = useMemo(() => import.meta.env.VITE_DEXHUNTER_PARTNER_CODE || 'l4va_test', []);
 
   const safeConfig = {
     theme: 'dark' as const,
@@ -127,7 +122,7 @@ export const SwapComponent: React.FC<SwapComponentProps> = ({ partnerName = 'l4v
 
       <div className="dexhunter-scope w-full">
         <SwapErrorBoundary>
-          <Swap partnerName={partnerName} partnerCode={resolvedPartnerCode} colors={DEFAULT_COLORS} {...safeConfig} />
+          <Swap partnerName="l4va" partnerCode={partnerCode} colors={DEFAULT_COLORS} {...safeConfig} />
         </SwapErrorBoundary>
       </div>
     </div>

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -593,6 +593,10 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
     );
   };
 
+  const vaultSwapToken = hasActiveLp
+    ? `${vault.policyId}${vault.assetVaultName}`
+    : import.meta.env.VITE_SWAP_VLRM_TOKEN_ID;
+
   return (
     <>
       {renderPublishedOverlay()}
@@ -637,9 +641,8 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
           <div className="w-full overflow-hidden lg:block hidden">
             <SwapComponent
               config={{
-                defaultToken: vault.hasActiveLp
-                  ? `${vault.policyId}${vault.assetVaultName}`
-                  : import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
+                defaultToken: vaultSwapToken,
+                supportedTokens: [vaultSwapToken],
                 style: { width: '100%' },
               }}
             />
@@ -672,9 +675,9 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
           <div className="bg-steel-950 rounded-xl p-4 overflow-hidden mx-auto w-full mt-4 lg:hidden block">
             <SwapComponent
               config={{
-                defaultToken: vault.hasActiveLp
-                  ? `${vault.policyId}${vault.assetVaultName}`
-                  : import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
+                defaultToken: vaultSwapToken,
+                supportedTokens: [vaultSwapToken],
+                style: { width: '100%' },
               }}
             />
           </div>


### PR DESCRIPTION
This pull request simplifies the configuration and usage of the `SwapComponent` by removing the `partnerName` and `partnerCode` props from its interface and internal logic, making these values static or environment-driven. Additionally, it improves how the default and supported tokens are set for the swap functionality in the vault profile view, ensuring consistency and reducing code duplication.

**Swap component simplification:**
* Removed `partnerName` and `partnerCode` from the `SwapComponentProps` interface and from the component’s props, making `partnerName` a static value and `partnerCode` determined solely by the environment variable or a default. [[1]](diffhunk://#diff-3c46b2de55720611ecf3e166ab6020b906668856d5ad0d8d3f082fe7ced850a6L13-L14) [[2]](diffhunk://#diff-3c46b2de55720611ecf3e166ab6020b906668856d5ad0d8d3f082fe7ced850a6L95-R94) [[3]](diffhunk://#diff-3c46b2de55720611ecf3e166ab6020b906668856d5ad0d8d3f082fe7ced850a6L130-R125)

**Vault profile swap configuration improvements:**
* Introduced a `vaultSwapToken` variable to centralize the logic for determining the default token based on the vault’s state.
* Updated the `SwapComponent` usage in `VaultProfileView` to use `vaultSwapToken` for both the `defaultToken` and `supportedTokens` configuration, ensuring only the relevant token is selectable and reducing repeated logic. [[1]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L640-R645) [[2]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L675-R680)