### PR TITLE
ADDED: console filtering for swap

### DIFF
--- a/src/components/swap/Swap.tsx
+++ b/src/components/swap/Swap.tsx
@@ -38,6 +38,34 @@ export interface SwapComponentProps {
   };
 }
 
+const suppressedKeywords = [
+  'RECONNECTING',
+  'default token',
+  'fetching token',
+  'settings new token',
+  'usdPrice',
+  'dexhunter',
+  'canceled',
+  'CanceledError',
+  'DialogContent',
+  'DialogTitle',
+];
+
+const originalConsole = { ...console };
+
+const createFilter =
+  (originalFn: any) =>
+  (...args: any[]) => {
+    const msg = args.join(' ');
+    if (suppressedKeywords.some(k => msg.includes(k))) return;
+    originalFn(...args);
+  };
+
+console.log = createFilter(originalConsole.log);
+console.warn = createFilter(originalConsole.warn);
+console.info = createFilter(originalConsole.info);
+console.debug = createFilter(originalConsole.debug);
+
 const DEFAULT_COLORS = {
   mainText: 'var(--color-text-primary)' as `#${string}`,
   subText: 'var(--color-dark-100)' as `#${string}`,


### PR DESCRIPTION
This pull request introduces a mechanism to filter out specific log messages in the `Swap.tsx` component. The main change is the suppression of console output containing certain keywords, which helps reduce noise in the development logs.

**Console log filtering:**

* Added a `suppressedKeywords` array and a `createFilter` function to override standard console methods (`log`, `warn`, `info`, `debug`) so that any messages containing specified keywords are not logged. This helps keep the console output clean by excluding less relevant or noisy messages.