### PR TITLE
Rename defaultToken to defaultTokenOut in SwapComponent configurations

### DIFF
--- a/src/components/swap/Swap.tsx
+++ b/src/components/swap/Swap.tsx
@@ -1,8 +1,4 @@
 import Swap from '@dexhunterio/swaps';
-import { defaultSettingsProps } from '@dexhunterio/swaps/lib/swap/page';
-import { SelectedWallet } from '@dexhunterio/swaps/lib/typescript/cardano-api';
-import { supportedTokensType } from '@dexhunterio/swaps/lib/swap/components/tokens';
-import { orderTypesProps } from '@dexhunterio/swaps/lib/store/createSwapSlice';
 import React, { useEffect, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import dexhunterStyles from '@dexhunterio/swaps/lib/assets/style.css?inline';
@@ -10,31 +6,12 @@ import dexhunterStyles from '@dexhunterio/swaps/lib/assets/style.css?inline';
 import { SwapErrorBoundary } from '@/components/swap/SwapErrorBoundary.tsx';
 
 export interface SwapComponentProps {
-  config?: {
-    defaultToken?: string;
-    width?: string;
-    height?: string;
-    theme?: 'light' | 'dark';
-    className?: string;
-    style?: React.CSSProperties;
-    orderTypes?: orderTypesProps;
-    supportedTokens?: supportedTokensType;
-    onSwapSuccess?: (data: any) => void;
-    onSwapError?: (err: any) => void;
-    onSwapWarning?: (err: any) => void;
-    selectedWallet?: SelectedWallet;
-    inputs?: string[];
-    onWalletConnect?: (data: any) => void;
-    onClickWalletConnect?: () => void;
-    onViewOrder?: (data: any) => void;
-    displayType?: 'BUTTON' | 'DEFAULT' | 'WIDGET';
-    buttonText?: string;
-    orderTypeOnButtonClick?: 'SWAP' | 'LIMIT' | 'DCA';
-    buttonStyle?: object;
-    buttonClassName?: string;
-    widgetButtonClass?: object;
-    defaultSettings?: defaultSettingsProps;
-    autoFocus?: boolean;
+  config?: Omit<
+    React.ComponentProps<typeof Swap>,
+    'partnerName' | 'partnerCode' | 'colors' | 'onSwapSuccess' | 'onSwapError'
+  > & {
+    onSwapSuccess?: (data: unknown) => void;
+    onSwapError?: (err: unknown) => void;
   };
 }
 
@@ -143,16 +120,17 @@ export const SwapComponent: React.FC<SwapComponentProps> = ({ config }) => {
     displayType: 'DEFAULT' as const,
     width: '100%',
     ...config,
-    onSwapSuccess: (data: any) => {
-      if (data?.data?.length > 0) {
+    onSwapSuccess: (data: unknown) => {
+      if (data && typeof data === 'object' && 'data' in data && Array.isArray(data.data) && data.data.length > 0) {
         toast.success('Swap transaction submitted successfully! Your transaction is being processed.', {
           duration: 5000,
         });
       }
       config?.onSwapSuccess?.(data);
     },
-    onSwapError: (err: any) => {
-      if (!err?.message?.toLowerCase().includes('cancel')) {
+    onSwapError: (err: unknown) => {
+      const message = err && typeof err === 'object' && 'message' in err ? String(err.message) : '';
+      if (!message.toLowerCase().includes('cancel')) {
         console.error('Swap error:', err);
         toast.error('Swap failed. Please try again.', { duration: 4000 });
       }

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -643,7 +643,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
           <div className="w-full overflow-hidden lg:block hidden">
             <SwapComponent
               config={{
-                defaultToken: vaultSwapToken,
+                defaultTokenOut: vaultSwapToken,
                 style: { width: '100%' },
               }}
             />
@@ -676,7 +676,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
           <div className="bg-steel-950 rounded-xl p-4 overflow-hidden mx-auto w-full mt-4 lg:hidden block">
             <SwapComponent
               config={{
-                defaultToken: vaultSwapToken,
+                defaultTokenOut: vaultSwapToken,
                 style: { width: '100%' },
               }}
             />

--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -1054,7 +1054,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
             <Suspense fallback={<div className="px-12 py-10 text-dark-100">Loading swap widget…</div>}>
               <LazySwapComponent
                 config={{
-                  defaultToken: import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
+                  defaultTokenOut: import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
                   supportedTokens: [import.meta.env.VITE_SWAP_VLRM_TOKEN_ID],
                 }}
               />

--- a/src/routes/swap.jsx
+++ b/src/routes/swap.jsx
@@ -9,7 +9,7 @@ export const SwapPage = () => {
 
       <SwapComponent
         config={{
-          defaultToken: import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
+          defaultTokenOut: import.meta.env.VITE_SWAP_VLRM_TOKEN_ID,
           supportedTokens: [import.meta.env.VITE_SWAP_VLRM_TOKEN_ID],
         }}
       />


### PR DESCRIPTION
This pull request refactors the `SwapComponent` props to better align with the underlying `Swap` component and updates how swap token defaults are passed throughout the codebase. It also improves type safety and error handling in swap event callbacks.

Component API changes:

* Refactored the `SwapComponentProps` `config` prop to use `Omit<React.ComponentProps<typeof Swap>, ...>` for better type alignment, and narrowed the callback types for `onSwapSuccess` and `onSwapError` to use `unknown` instead of `any`.

Swap token configuration updates:

* Replaced all usages of `defaultToken` with `defaultTokenOut` when passing the default token to `SwapComponent` in `VaultProfileView.jsx`, `CreateVaultForm.jsx`, and `swap.jsx` to match the expected prop name. [[1]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L646-R646) [[2]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L679-R679) [[3]](diffhunk://#diff-691b675959c4129717e2094265c0721504f8735f992f444b5416e49349405fcaL1057-R1057) [[4]](diffhunk://#diff-90aa62f41cfa591e2c3b97e384767f4fa38fd25ca805809bf6890f6ab662f400L12-R12)

Event handler improvements:

* Enhanced the `onSwapSuccess` and `onSwapError` handlers in `Swap.tsx` to include additional type checks and safer access to properties, improving robustness and preventing runtime errors.