### PR TITLE
FIXED: swap component on vault creation

### DIFF
--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -1049,7 +1049,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
       </>
       <>{renderButtons()}</>
       <Dialog open={isVisibleSwipe} onOpenChange={() => setIsVisibleSwipe(false)}>
-        <DialogContent className="sm:max-w-4xl items-center justify-center pt-8 bg-steel-950 border-none max-h-[90vh] flex w-fit">
+        <DialogContent className="sm:max-w-4xl items-center justify-center pt-8 bg-steel-950 border-none max-h-[90vh] flex w-full">
           {isVisibleSwipe ? (
             <Suspense fallback={<div className="px-12 py-10 text-dark-100">Loading swap widget…</div>}>
               <LazySwapComponent


### PR DESCRIPTION
This pull request makes a small UI adjustment to the `CreateVaultForm` component. The width of the `DialogContent` element is changed from `w-fit` to `w-full`, ensuring that the dialog now takes up the full available width rather than just fitting its content.

- Changed `DialogContent` in `CreateVaultForm.jsx` to use `w-full` instead of `w-fit` for width, making the dialog expand to the full width of its container.