### PR TITLE
ADDED: rewards card next to staking widget

### DIFF
--- a/src/components/rewards/CurrentEpochBanner.jsx
+++ b/src/components/rewards/CurrentEpochBanner.jsx
@@ -2,6 +2,64 @@ import { Calendar, TrendingUp } from 'lucide-react';
 
 import { formatDateRange } from '@/utils/rewards/normalizers';
 
+export const CurrentEpochInfoCard = ({ epoch, isLoading = false, showCalendarIcon = true }) => {
+  if (isLoading) {
+    return (
+      <div className="rounded-xl border border-steel-750 bg-steel-900/60 p-5 flex items-center gap-4">
+        {showCalendarIcon && <div className="w-14 h-14 rounded-xl bg-gray-700 animate-pulse flex-shrink-0" />}
+        <div className="min-w-0 flex-1 space-y-2">
+          <div className="h-4 bg-gray-700 rounded animate-pulse w-1/3" />
+          <div className="h-6 bg-gray-700 rounded animate-pulse w-4/5" />
+          <div className="h-4 bg-gray-700 rounded animate-pulse w-1/2" />
+        </div>
+      </div>
+    );
+  }
+
+  if (!epoch) {
+    return (
+      <div className="rounded-xl border border-steel-750 bg-steel-900/60 p-5 flex items-center">
+        <p className="text-sm text-steel-400">No active epoch at the moment</p>
+      </div>
+    );
+  }
+
+  const statusDotColors = {
+    active: 'bg-green-500',
+    processing: 'bg-yellow-500',
+    finalized: 'bg-blue-500',
+  };
+
+  const statusLabels = {
+    active: 'Active',
+    processing: 'Processing',
+    finalized: 'Finalized',
+  };
+
+  return (
+    <div className="rounded-xl border border-steel-750 bg-steel-900/60 p-5 flex items-center gap-4">
+      {showCalendarIcon && (
+        <div className="w-14 h-14 rounded-xl bg-purple-500/20 flex items-center justify-center flex-shrink-0 border border-purple-500/20">
+          <Calendar className="w-8 h-8 text-purple-500" />
+        </div>
+      )}
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-3 mb-1">
+          <p className="text-steel-400 text-xs font-medium uppercase tracking-wide">Current Epoch</p>
+          <div className="flex items-center gap-2">
+            <div
+              className={`w-2 h-2 rounded-full ${statusDotColors[epoch.status] || 'bg-gray-500'} ${epoch.status === 'active' ? 'animate-pulse' : ''}`}
+            />
+            <span className="text-xs text-steel-400">{statusLabels[epoch.status] || epoch.status}</span>
+          </div>
+        </div>
+        <p className="text-xl font-bold text-white mb-1">{formatDateRange(epoch.startDate, epoch.endDate)}</p>
+        {epoch.epochNumber && <p className="text-sm text-steel-500">Epoch #{epoch.epochNumber}</p>}
+      </div>
+    </div>
+  );
+};
+
 export const CurrentEpochBanner = ({ epoch, isLoading = false }) => {
   if (isLoading) {
     return (
@@ -27,39 +85,9 @@ export const CurrentEpochBanner = ({ epoch, isLoading = false }) => {
     );
   }
 
-  const statusDotColors = {
-    active: 'bg-green-500',
-    processing: 'bg-yellow-500',
-    finalized: 'bg-blue-500',
-  };
-
-  const statusLabels = {
-    active: 'Active',
-    processing: 'Processing',
-    finalized: 'Finalized',
-  };
-
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-4 p-5 md:p-6">
-      {/* Epoch Info Card */}
-      <div className="rounded-xl border border-steel-750 bg-steel-900/60 p-5 flex items-center gap-4">
-        <div className="w-14 h-14 rounded-xl bg-purple-500/20 flex items-center justify-center flex-shrink-0 border border-purple-500/20">
-          <Calendar className="w-8 h-8 text-purple-500" />
-        </div>
-        <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-3 mb-1">
-            <p className="text-steel-400 text-xs font-medium uppercase tracking-wide">Current Epoch</p>
-            <div className="flex items-center gap-2">
-              <div
-                className={`w-2 h-2 rounded-full ${statusDotColors[epoch.status] || 'bg-gray-500'} ${epoch.status === 'active' ? 'animate-pulse' : ''}`}
-              />
-              <span className="text-xs text-steel-400">{statusLabels[epoch.status] || epoch.status}</span>
-            </div>
-          </div>
-          <p className="text-xl font-bold text-white mb-1">{formatDateRange(epoch.startDate, epoch.endDate)}</p>
-          {epoch.epochNumber && <p className="text-sm text-steel-500">Epoch #{epoch.epochNumber}</p>}
-        </div>
-      </div>
+      <CurrentEpochInfoCard epoch={epoch} />
 
       {/* Total Emission Card */}
       {epoch.emissionTotal && (

--- a/src/components/rewards/TotalEarnedCard.jsx
+++ b/src/components/rewards/TotalEarnedCard.jsx
@@ -1,0 +1,27 @@
+import { Trophy } from 'lucide-react';
+
+export const TotalEarnedCard = ({
+  totalEarned = 0,
+  className = '',
+  isLoading = false,
+  showIcon = true,
+  label = 'Total Earned',
+  labelClassName = 'text-steel-400 text-xs font-medium uppercase tracking-wide',
+  valueClassName = 'text-xl font-bold text-orange-400',
+}) => {
+  return (
+    <div className={`bg-steel-850 border border-steel-750 rounded-2xl p-5 ${className}`.trim()}>
+      <div className="flex items-center gap-3">
+        {showIcon && (
+          <div className="w-11 h-11 rounded-lg bg-orange-500/20 border border-orange-500/20 flex items-center justify-center flex-shrink-0">
+            <Trophy className="w-5 h-5 text-orange-500" />
+          </div>
+        )}
+        <div>
+          <p className={labelClassName}>{label}</p>
+          <p className={valueClassName}>{isLoading ? '...' : `${Number(totalEarned || 0).toLocaleString()} $L4VA`}</p>
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/components/rewards/index.jsx
+++ b/src/components/rewards/index.jsx
@@ -9,11 +9,13 @@ export { VaultLeaderboard } from './VaultLeaderboard';
 
 // Summary Components
 export { RewardsSummaryCards } from './RewardsSummaryCards';
+export { TotalEarnedCard } from './TotalEarnedCard';
 export { VestingSummary } from './VestingSummary';
 
 // Epoch Components
 export { EpochSelector } from './EpochSelector';
 export { CurrentEpochBanner } from './CurrentEpochBanner';
+export { CurrentEpochInfoCard } from './CurrentEpochBanner';
 export { EpochStatusBadge } from './EpochStatusBadge';
 export { EpochRewardRow } from './EpochRewardRow';
 

--- a/src/pages/profile/ProfileRewardsLinkCard.jsx
+++ b/src/pages/profile/ProfileRewardsLinkCard.jsx
@@ -1,0 +1,60 @@
+import { Link } from '@tanstack/react-router';
+import { ChevronRight, TrendingUp } from 'lucide-react';
+import { useWallet } from '@ada-anvil/weld/react';
+
+import { CurrentEpochInfoCard, TotalEarnedCard } from '@/components/rewards';
+import { useCurrentEpoch } from '@/hooks/useRewardsEpochs';
+import { useCurrentEpochEstimate, useWalletHistory } from '@/hooks/useRewardsScore';
+import { formatCompactNumber } from '@/utils/core.utils';
+
+export const ProfileRewardsLinkCard = () => {
+  const { changeAddressBech32: walletAddress } = useWallet();
+  const { data: epochData, isLoading: isEpochLoading } = useCurrentEpoch();
+  const { data: estimateData, isLoading: isEstimateLoading } = useCurrentEpochEstimate(walletAddress);
+  const { data: historyData, isLoading: isHistoryLoading } = useWalletHistory(walletAddress);
+
+  const epoch = epochData?.epoch;
+  const estimateValue = estimateData?.estimatedReward;
+  const totalEarned = historyData?.history?.reduce((sum, item) => sum + (Number(item.finalReward) || 0), 0) || 0;
+
+  return (
+    <Link
+      to="/rewards"
+      className="group h-full rounded-2xl border border-steel-750 bg-steel-950 p-5 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.7)] transition-colors hover:border-steel-600"
+    >
+      <div className="flex h-full min-h-[260px] flex-col justify-between gap-5">
+        <div className="flex items-start justify-between gap-3">
+          <div className="min-w-0">
+            <div className="text-[12px] tracking-[0.12em] uppercase text-dark-100">Rewards</div>
+            <div className="mt-2 text-[18px] leading-tight font-semibold text-white">L4VA rewards this week</div>
+            <div className="mt-2 text-[13px] text-dark-100">Open rewards dashboard, claims and epochs</div>
+          </div>
+          <ChevronRight className="mt-1 h-5 w-5 shrink-0 text-dark-100 transition-transform group-hover:translate-x-1 group-hover:text-white" />
+        </div>
+
+        <div className="space-y-3">
+          <CurrentEpochInfoCard epoch={epoch} isLoading={isEpochLoading} showCalendarIcon={false} />
+
+          <div className="rounded-xl border border-steel-750 bg-steel-900/50 p-4">
+            <div className="flex items-center gap-2 text-[11px] uppercase tracking-wide text-dark-100">
+              <TrendingUp className="h-3.5 w-3.5" />
+              <span>Epoch estimate</span>
+            </div>
+            <div className="mt-2 text-[20px] font-semibold text-white">
+              {isEstimateLoading ? '...' : `~${formatCompactNumber(estimateValue || 0)} $L4VA`}
+            </div>
+          </div>
+
+          <TotalEarnedCard
+            totalEarned={totalEarned}
+            isLoading={isHistoryLoading}
+            className="bg-steel-900/50 p-4"
+            showIcon={false}
+            labelClassName="text-[11px] uppercase tracking-wide text-dark-100"
+            valueClassName="mt-2 text-[20px] font-semibold text-white"
+          />
+        </div>
+      </div>
+    </Link>
+  );
+};

--- a/src/pages/profile/StakingWidget.tsx
+++ b/src/pages/profile/StakingWidget.tsx
@@ -169,14 +169,14 @@ export const StakingWidget: React.FC = () => {
   }, [vlrmAmount, l4vaAmount]);
 
   return (
-    <div className="w-full max-w-[920px] mx-auto">
-      <div className="rounded-2xl border border-steel-750 bg-steel-950 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.7)]">
+    <div className="flex w-full">
+      <div className="w-full rounded-2xl border border-steel-750 bg-steel-950 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.7)]">
         {/* Header */}
         <div className="px-4 sm:px-6 pt-5 sm:pt-6 pb-4">
           <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div className="min-w-0">
-              <div className="text-[13px] tracking-[0.12em] uppercase text-dark-100 flex items-center gap-2">
-                <span>Staking</span>
+              <div className="flex items-center gap-2">
+                <div className="text-[18px] sm:text-[20px] font-semibold text-white">Staking Widget</div>
                 <HoverHelp
                   hint={
                     'Stake creates individual on-chain boxes (UTxOs).\n\n' +
@@ -189,9 +189,6 @@ export const StakingWidget: React.FC = () => {
                     '- Compound: restakes deposit + reward into a new box; nothing is sent to wallet.'
                   }
                 />
-              </div>
-              <div className="mt-1 flex items-center gap-2">
-                <div className="text-[18px] sm:text-[20px] font-semibold text-white">Staking Widget</div>
                 <Button
                   type="button"
                   variant="ghost"

--- a/src/pages/profile/index.jsx
+++ b/src/pages/profile/index.jsx
@@ -11,6 +11,7 @@ import { Spinner } from '@/components/Spinner.jsx';
 import { UserPublicVaultsList } from '@/components/vaults/UserPublicVaultsList.jsx';
 import { Transactions } from '@/pages/profile/Transactions.jsx';
 import { StakingWidget } from '@/pages/profile/StakingWidget';
+import { ProfileRewardsLinkCard } from '@/pages/profile/ProfileRewardsLinkCard';
 
 export const Profile = ({ userId, isEditable }) => {
   const { user } = useAuth();
@@ -35,7 +36,14 @@ export const Profile = ({ userId, isEditable }) => {
       <div className="flex flex-col gap-20">
         <Stats user={userData} />
         <ProfileSocialLinks user={userData} isEditable={isEditable} />
-        {!userId && <StakingWidget />}
+        {!userId && (
+          <div className="w-full">
+            <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_340px] gap-4 xl:gap-6 items-stretch">
+              <StakingWidget />
+              <ProfileRewardsLinkCard />
+            </div>
+          </div>
+        )}
         {userId && <UserPublicVaultsList ownerId={userId} />}
         {!userId && <MyVaultsList initialTab={search?.tab} />}
         {!userId && <Claims />}

--- a/src/pages/rewards/EpochsList.jsx
+++ b/src/pages/rewards/EpochsList.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { useNavigate } from '@tanstack/react-router';
-import { Calendar, Wallet, ArrowLeft, TrendingUp, Trophy } from 'lucide-react';
+import { Calendar, Wallet, ArrowLeft, TrendingUp } from 'lucide-react';
 import { useWallet } from '@ada-anvil/weld/react';
 
 import { useEpochs } from '@/hooks/useRewardsEpochs';
 import { useWalletHistory } from '@/hooks/useRewardsScore';
-import { EpochRewardRow } from '@/components/rewards';
+import { EpochRewardRow, TotalEarnedCard } from '@/components/rewards';
 
 export const EpochsList = () => {
   const navigate = useNavigate();
@@ -21,6 +21,10 @@ export const EpochsList = () => {
   const rewardsByEpoch = React.useMemo(() => {
     if (!historyData?.history) return new Map();
     return new Map(historyData.history.map(item => [item.epochId, item]));
+  }, [historyData]);
+
+  const totalEarned = React.useMemo(() => {
+    return historyData?.history?.reduce((sum, item) => sum + (Number(item.finalReward) || 0), 0) || 0;
   }, [historyData]);
 
   // Wallet not connected state
@@ -105,22 +109,7 @@ export const EpochsList = () => {
                 </div>
               </div>
             </div>
-            <div className="bg-steel-850 border border-steel-750 rounded-2xl p-5">
-              <div className="flex items-center gap-3">
-                <div className="w-11 h-11 rounded-lg bg-orange-500/20 border border-orange-500/20 flex items-center justify-center flex-shrink-0">
-                  <Trophy className="w-5 h-5 text-orange-500" />
-                </div>
-                <div>
-                  <p className="text-steel-400 text-xs font-medium uppercase tracking-wide">Total Earned</p>
-                  <p className="text-xl font-bold text-orange-400">
-                    {historyData.history
-                      .reduce((sum, item) => sum + (Number(item.finalReward) || 0), 0)
-                      .toLocaleString()}{' '}
-                    $L4VA
-                  </p>
-                </div>
-              </div>
-            </div>
+            <TotalEarnedCard totalEarned={totalEarned} />
             <div className="bg-steel-850 border border-steel-750 rounded-2xl p-5">
               <div className="flex items-center gap-3">
                 <div className="w-11 h-11 rounded-lg bg-green-500/20 border border-green-500/20 flex items-center justify-center flex-shrink-0">
@@ -129,11 +118,7 @@ export const EpochsList = () => {
                 <div>
                   <p className="text-steel-400 text-xs font-medium uppercase tracking-wide">Avg Per Epoch</p>
                   <p className="text-xl font-bold text-white">
-                    {(
-                      historyData.history.reduce((sum, item) => sum + (Number(item.finalReward) || 0), 0) /
-                      historyData.history.length
-                    ).toLocaleString()}{' '}
-                    $L4VA
+                    {(totalEarned / historyData.history.length).toLocaleString()} $L4VA
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
This pull request introduces a new `TotalEarnedCard` component for displaying total rewards earned, refactors the current epoch banner into two components for better reuse, and improves the layout and modularity of the rewards and profile pages. These changes enhance code reusability, UI consistency, and maintainability across the rewards and profile sections.

**Component extraction and reuse:**

* Added a new `TotalEarnedCard` component to display the total earned rewards in a reusable way, replacing inline implementations in rewards-related pages (`src/components/rewards/TotalEarnedCard.jsx`, [src/components/rewards/TotalEarnedCard.jsxR1-R27](diffhunk://#diff-b76dde93718cb16e80479750f630e2d5fb5fd36be9b97dca96aa97f8359f0566R1-R27)).
* Refactored the epoch banner logic by extracting `CurrentEpochInfoCard` from `CurrentEpochBanner`, allowing for more flexible use of epoch information cards in different contexts (`src/components/rewards/CurrentEpochBanner.jsx`, [[1]](diffhunk://#diff-290d3d574a0d5b90cbbfd7f021e73f79a21004dcd9cdc10cfa1da893dd470f26L5-R22) [[2]](diffhunk://#diff-290d3d574a0d5b90cbbfd7f021e73f79a21004dcd9cdc10cfa1da893dd470f26L43-R45) [[3]](diffhunk://#diff-290d3d574a0d5b90cbbfd7f021e73f79a21004dcd9cdc10cfa1da893dd470f26R60-R90).

**Profile and rewards page improvements:**

* Introduced a new `ProfileRewardsLinkCard` component on the profile page, providing users with a summary and quick access to their rewards dashboard, including current epoch info, estimated rewards, and total earned (`src/pages/profile/ProfileRewardsLinkCard.jsx`, [src/pages/profile/ProfileRewardsLinkCard.jsxR1-R60](diffhunk://#diff-f8615bf618f4fa4ba86297b21f538b8abd1894c7465d3e10002670fa49ac2947R1-R60)).
* Updated the profile page layout to display both the `StakingWidget` and the new `ProfileRewardsLinkCard` side by side for non-user-specific profiles, improving the user experience (`src/pages/profile/index.jsx`, [[1]](diffhunk://#diff-8fa0600d4a39a7e2b81835bb2bddb752233eee0bff00793769828125a3be3577R14) [[2]](diffhunk://#diff-8fa0600d4a39a7e2b81835bb2bddb752233eee0bff00793769828125a3be3577L38-R46).
* Updated the rewards epochs list to use the new `TotalEarnedCard` component, ensuring consistent display of total rewards earned (`src/pages/rewards/EpochsList.jsx`, [[1]](diffhunk://#diff-cf13d5d8921f171a9c24e809cc9cb0cc87f5ad71a2e81000c54b2a6847fe3b84L3-R8) [[2]](diffhunk://#diff-cf13d5d8921f171a9c24e809cc9cb0cc87f5ad71a2e81000c54b2a6847fe3b84L108-R110).

**UI and code cleanup:**

* Improved the loading and empty states for both the epoch info card and the banner, ensuring consistent styling and skeleton loaders (`src/components/rewards/CurrentEpochBanner.jsx`, [[1]](diffhunk://#diff-290d3d574a0d5b90cbbfd7f021e73f79a21004dcd9cdc10cfa1da893dd470f26L5-R22) [[2]](diffhunk://#diff-290d3d574a0d5b90cbbfd7f021e73f79a21004dcd9cdc10cfa1da893dd470f26R60-R90).
* Made minor adjustments to the `StakingWidget` header for better clarity and alignment (`src/pages/profile/StakingWidget.tsx`, [[1]](diffhunk://#diff-4cbcb29965e5bc4282e56bd5dd1c2bad8bd47c0eaccd393bf4fd6f2c3b645f33L172-R179) [[2]](diffhunk://#diff-4cbcb29965e5bc4282e56bd5dd1c2bad8bd47c0eaccd393bf4fd6f2c3b645f33L192-L194).

**Exports and imports:**

* Updated exports in the rewards components index to include the new and refactored components for easier imports elsewhere (`src/components/rewards/index.jsx`, [src/components/rewards/index.jsxR12-R18](diffhunk://#diff-9fcac31554ff0f9a7c63721dead4b86db9f57b70f9ecae6f69207c4136b10ebdR12-R18)).

These changes collectively improve the modularity and maintainability of the rewards and profile UI components, while also enhancing the user experience with more consistent and informative displays.