### PR TITLE
Add LP token support and enhance asset whitelist display

### DIFF
--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -1,4 +1,4 @@
-import { X, Plus, ChevronDown, ChevronUp, Loader2, ShieldCheck, ShieldAlert, Info } from 'lucide-react';
+import { X, Plus, ChevronDown, ChevronUp, Loader2, ShieldCheck, ShieldAlert } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
 import toast from 'react-hot-toast';

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -252,8 +252,8 @@ export const LavaWhitelistWithCaps = ({
             policyName: update.name || asset.policyName || 'N/A',
           };
 
-          // Auto-set LP token valuation method
-          if (update.isLpToken && !updatedAsset.valuationMethod) {
+          // LP token detection should override any previously selected non-LP valuation method
+          if (update.isLpToken) {
             updatedAsset.valuationMethod = 'lp_token_dynamic';
           }
 

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -1,4 +1,4 @@
-import { X, Plus, ChevronDown, ChevronUp, Loader2, ShieldCheck, ShieldAlert } from 'lucide-react';
+import { X, Plus, ChevronDown, ChevronUp, Loader2, ShieldCheck, ShieldAlert, Info } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
 import toast from 'react-hot-toast';
@@ -245,7 +245,7 @@ export const LavaWhitelistWithCaps = ({
         const nextWhitelist = whitelist.map(asset => {
           const update = updatesByUniqueId[asset.uniqueId];
           if (!update || (asset.isVerified !== undefined && asset.isVerified !== null)) return asset;
-          
+
           const updatedAsset = {
             ...asset,
             ...update,
@@ -601,7 +601,7 @@ export const LavaWhitelistWithCaps = ({
                     name={`valuationMethod_${asset.uniqueId}`}
                     options={
                       asset.isLpToken
-                        ? [{ name: 'lp_token_dynamic', label: 'LP Token Dynamic Price' }]
+                        ? [{ name: 'lp_token_dynamic', label: 'LP Token Price' }]
                         : [
                             { name: 'market', label: 'Market / Floor Price' },
                             { name: 'custom', label: 'Custom Price' },
@@ -616,7 +616,7 @@ export const LavaWhitelistWithCaps = ({
                     disabled={asset.isLpToken}
                   />
                   {asset.isLpToken && (
-                    <p className="text-sm text-blue-400 mt-2">LP tokens use dynamic pricing calculated from pool TVL</p>
+                    <p className="text-xs text-gray-400 mt-1 ml-6">Price = Pool TVL ÷ Total LP Token Supply</p>
                   )}
                   {(() => {
                     const index = whitelist.findIndex(item => item.uniqueId === asset.uniqueId);

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -215,6 +215,7 @@ export const LavaWhitelistWithCaps = ({
               name: localMatch.name || asset.name || '',
               assetName: localMatch.assetName || asset.assetName || '',
               count: localMatch.count || asset.count || 1,
+              isLpToken: localMatch.isLpToken ?? false,
             };
           } else {
             needsApiLookup.push(asset);
@@ -234,6 +235,7 @@ export const LavaWhitelistWithCaps = ({
               name: result.name || asset.name || '',
               assetName: result.assetName || asset.assetName || '',
               count: result.count || asset.count || 1,
+              isLpToken: result.isLpToken ?? false,
             };
           });
         }
@@ -243,11 +245,19 @@ export const LavaWhitelistWithCaps = ({
         const nextWhitelist = whitelist.map(asset => {
           const update = updatesByUniqueId[asset.uniqueId];
           if (!update || (asset.isVerified !== undefined && asset.isVerified !== null)) return asset;
-          return {
+          
+          const updatedAsset = {
             ...asset,
             ...update,
             policyName: update.name || asset.policyName || 'N/A',
           };
+
+          // Auto-set LP token valuation method
+          if (update.isLpToken && !updatedAsset.valuationMethod) {
+            updatedAsset.valuationMethod = 'lp_token_dynamic';
+          }
+
+          return updatedAsset;
         });
 
         const hasChanges = nextWhitelist.some((asset, index) => asset !== whitelist[index]);
@@ -589,13 +599,25 @@ export const LavaWhitelistWithCaps = ({
                   <LavaRadio
                     label="*Asset Valuation Method"
                     name={`valuationMethod_${asset.uniqueId}`}
-                    options={[
-                      { name: 'market', label: 'Market / Floor Price' },
-                      { name: 'custom', label: 'Custom Price' },
-                    ]}
-                    value={asset.valuationMethod || 'market'}
-                    onChange={value => updateAsset(asset.uniqueId, 'valuationMethod', value)}
+                    options={
+                      asset.isLpToken
+                        ? [{ name: 'lp_token_dynamic', label: 'LP Token Dynamic Price' }]
+                        : [
+                            { name: 'market', label: 'Market / Floor Price' },
+                            { name: 'custom', label: 'Custom Price' },
+                          ]
+                    }
+                    value={asset.isLpToken ? 'lp_token_dynamic' : asset.valuationMethod || 'market'}
+                    onChange={value => {
+                      if (!asset.isLpToken) {
+                        updateAsset(asset.uniqueId, 'valuationMethod', value);
+                      }
+                    }}
+                    disabled={asset.isLpToken}
                   />
+                  {asset.isLpToken && (
+                    <p className="text-sm text-blue-400 mt-2">LP tokens use dynamic pricing calculated from pool TVL</p>
+                  )}
                   {(() => {
                     const index = whitelist.findIndex(item => item.uniqueId === asset.uniqueId);
                     return (
@@ -604,7 +626,7 @@ export const LavaWhitelistWithCaps = ({
                   })()}
                 </div>
 
-                {asset.valuationMethod === 'custom' && (
+                {asset.valuationMethod === 'custom' && !asset.isLpToken && (
                   <div>
                     <LavaInput
                       required={true}

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -40,6 +40,8 @@ type CollectionLookupRaw = {
   is_verified?: boolean;
   platform?: unknown;
   tokenVerification?: { platform?: unknown; is_verified?: boolean };
+  isLpToken?: boolean;
+  is_lp_token?: boolean;
 };
 
 function normalizeCollectionLookupItem(raw: CollectionLookupRaw): {
@@ -47,13 +49,15 @@ function normalizeCollectionLookupItem(raw: CollectionLookupRaw): {
   collectionName: string | null;
   isVerified: boolean;
   verificationPlatform: VerificationPlatform | null;
+  isLpToken: boolean;
 } {
   const policyId = raw.policyId ?? raw.policy_id ?? '';
   const collectionName = raw.collectionName ?? raw.collection_name ?? null;
   const isVerified = raw.isVerified ?? raw.is_verified ?? false;
   const platformRaw = raw.platform ?? raw.tokenVerification?.platform;
   const verificationPlatform = isVerified ? parseVerificationPlatform(platformRaw) : null;
-  return { policyId, collectionName, isVerified, verificationPlatform };
+  const isLpToken = raw.isLpToken ?? raw.is_lp_token ?? false;
+  return { policyId, collectionName, isVerified, verificationPlatform, isLpToken };
 }
 
 export interface WalletAsset {
@@ -73,6 +77,8 @@ export interface GroupedPolicy {
   isVerified: boolean;
   /** Present when `isVerified` and API returned a platform */
   verificationPlatform: VerificationPlatform | null;
+  /** Whether this is an LP token requiring dynamic pricing */
+  isLpToken?: boolean;
 }
 
 const PAGE_SIZE = 10;
@@ -186,7 +192,7 @@ export const useAssets = () => {
   const collectionNamesCache = useRef<
     Map<
       string,
-      { collectionName: string | null; isVerified: boolean; verificationPlatform: VerificationPlatform | null }
+      { collectionName: string | null; isVerified: boolean; verificationPlatform: VerificationPlatform | null; isLpToken: boolean }
     >
   >(new Map());
   /** Serializes cache-miss fetches so parallel callers (Strict Mode, open + search) share one wave of HTTP requests */
@@ -232,6 +238,7 @@ export const useAssets = () => {
                 collectionName: normalized.collectionName,
                 isVerified: normalized.isVerified,
                 verificationPlatform: normalized.verificationPlatform,
+                isLpToken: normalized.isLpToken,
               });
             });
           } catch (error) {
@@ -241,6 +248,7 @@ export const useAssets = () => {
                 collectionName: null,
                 isVerified: false,
                 verificationPlatform: null,
+                isLpToken: false,
               });
             });
           }
@@ -254,6 +262,7 @@ export const useAssets = () => {
           collectionName: cached?.collectionName ?? null,
           isVerified: cached?.isVerified ?? false,
           verificationPlatform: cached?.verificationPlatform ?? null,
+          isLpToken: cached?.isLpToken ?? false,
         };
       });
     };

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -78,7 +78,7 @@ export interface GroupedPolicy {
   /** Present when `isVerified` and API returned a platform */
   verificationPlatform: VerificationPlatform | null;
   /** Whether this is an LP token requiring dynamic pricing */
-  isLpToken?: boolean;
+  isLpToken: boolean;
 }
 
 const PAGE_SIZE = 10;

--- a/src/hooks/useAssets.ts
+++ b/src/hooks/useAssets.ts
@@ -162,7 +162,10 @@ function walletPolicySetKey(grouped: GroupedPolicyBase[]): string {
 }
 
 const groupAssetsByPolicy = (assets: WalletAsset[]): GroupedPolicyBase[] => {
-  const grouped = new Map<string, { policyId: string; name: string; assetName: string; count: number }>();
+  const grouped = new Map<
+    string,
+    { policyId: string; name: string; assetName: string; count: number; isLpToken: boolean }
+  >();
 
   assets.forEach(asset => {
     if (grouped.has(asset.policyId)) {
@@ -174,6 +177,7 @@ const groupAssetsByPolicy = (assets: WalletAsset[]): GroupedPolicyBase[] => {
         name: asset.name,
         assetName: asset.assetNameHex,
         count: 1,
+        isLpToken: false,
       });
     }
   });
@@ -192,7 +196,12 @@ export const useAssets = () => {
   const collectionNamesCache = useRef<
     Map<
       string,
-      { collectionName: string | null; isVerified: boolean; verificationPlatform: VerificationPlatform | null; isLpToken: boolean }
+      {
+        collectionName: string | null;
+        isVerified: boolean;
+        verificationPlatform: VerificationPlatform | null;
+        isLpToken: boolean;
+      }
     >
   >(new Map());
   /** Serializes cache-miss fetches so parallel callers (Strict Mode, open + search) share one wave of HTTP requests */
@@ -351,7 +360,7 @@ export const useAssets = () => {
       if (policyIds.length === 0) return [];
       const items: GroupedPolicyBase[] = policyIds.map(id => {
         const existing = allGroupedRef.current.find(p => p.policyId === id);
-        return existing ?? { policyId: id, name: '', assetName: '', count: 1 };
+        return existing ?? { policyId: id, name: '', assetName: '', count: 1, isLpToken: false };
       });
       return fetchCollections(items);
     },


### PR DESCRIPTION
This pull request adds support for identifying and handling LP (liquidity pool) tokens throughout the asset management and whitelist UI. The changes ensure that LP tokens are detected, displayed with appropriate valuation methods, and have their pricing logic and UI controls adjusted accordingly. The update also propagates the `isLpToken` property through asset grouping, normalization, and caching logic.

**LP Token Detection and Propagation:**

- Added the `isLpToken` (and `is_lp_token`) property to asset normalization in `useAssets.ts`, ensuring it is included in the normalized asset object and all related types, caches, and grouping logic. [[1]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R43-R60) [[2]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R80-R81) [[3]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490L159-R168) [[4]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R180) [[5]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490L189-R204) [[6]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R250) [[7]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R260) [[8]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490R274) [[9]](diffhunk://#diff-a96772d9f9608d1231e0e69dba57250a7f1a981a89e7c3d196a801bfaa51e490L345-R363)

**Whitelist and UI Behavior for LP Tokens:**

- Updated the whitelist mapping logic in `LavaWhitelistWithCaps.jsx` to include the `isLpToken` property when merging asset data, both for local and API lookups. [[1]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1R218) [[2]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1R238)
- When updating whitelist assets, if an asset is detected as an LP token, its valuation method is forcibly set to `'lp_token_dynamic'` to override any user-selected non-LP valuation method.

**Valuation Method UI Adjustments:**

- Modified the valuation method radio options in the UI: if an asset is an LP token, only the `'lp_token_dynamic'` option is shown, the selection is locked, and a descriptive note is displayed. Non-LP assets retain the standard options.
- The custom price input is now only shown for non-LP assets, preventing users from setting a custom price for LP tokens.