### PR TITLE
Update pricing method label to include LP token dynamic valuation

### DIFF
--- a/src/components/vault-profile/VaultSettings.jsx
+++ b/src/components/vault-profile/VaultSettings.jsx
@@ -18,7 +18,11 @@ import { formatAdaPrice, formatPolicyId } from '@/utils/core.utils.js';
 const collectionDisplayName = asset =>
   asset.collectionName?.trim() || asset.name?.trim() || asset.policyName?.trim() || null;
 
-const pricingMethodLabel = valuationMethod => (valuationMethod === 'custom' ? 'Custom' : 'Market / Floor');
+const pricingMethodLabel = valuationMethod => {
+  if (valuationMethod === 'custom') return 'Custom';
+  if (valuationMethod === 'lp_token_dynamic') return 'LP Token Price';
+  return 'Market / Floor';
+};
 
 export const VaultSettings = ({ vault }) => {
   const [showConfirmation, setShowConfirmation] = useState(false);

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -146,7 +146,7 @@ const assetWhitelistItemSchema = yup.object({
     .oneOf([true], 'Only verified collections can be added to a vault'),
   countCapMin: yup.mixed().default(1),
   countCapMax: yup.mixed().default(1000),
-  valuationMethod: yup.string().oneOf(['market', 'custom']).default('market'),
+  valuationMethod: yup.string().oneOf(['market', 'custom', 'lp_token_dynamic']).default('market'),
   customPriceAda: yup.number().when('valuationMethod', {
     is: 'custom',
     then: schema =>


### PR DESCRIPTION
This pull request updates the vault settings to support a new valuation method called "LP Token Price." The changes ensure that both the UI and validation schema recognize and properly label this new option alongside the existing "Market / Floor" and "Custom" methods.

**Valuation Method Enhancements:**

* Added support for the new `lp_token_dynamic` valuation method in the `assetWhitelistItemSchema` validation, allowing it as a valid option for asset valuation.
* Updated the `pricingMethodLabel` function in `VaultSettings.jsx` to display "LP Token Price" when the `lp_token_dynamic` valuation method is selected, ensuring the UI reflects the new option.