### PR TITLE
Increase asset whitelist cap and clean up ContributeModal

### DIFF
--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -193,64 +193,93 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     });
   }, []);
 
-  const handleFTAmountChange = useCallback((ft, amount) => {
-    // Get decimals from metadata, default to 6 if not specified
-    const decimals = ft.metadata?.decimals ?? 6;
+  const handleFTAmountChange = useCallback(
+    (ft, amount) => {
+      // Get decimals from metadata, default to 6 if not specified
+      const decimals = ft.metadata?.decimals ?? 6;
 
-    // Allow empty string or valid decimal numbers with decimals matching the token
-    const maxDecimals = Math.min(decimals, 8); // Cap display decimals at 8 for UX
-    const decimalPattern = new RegExp(`^\\d+(\\.\\d{0,${maxDecimals}})?$`);
-    const isValid = amount === '' || decimalPattern.test(amount);
+      console.log(ft, amount, decimals);
 
-    if (!isValid) return;
+      // Allow empty string or valid decimal numbers with decimals matching the token
+      const maxDecimals = Math.min(decimals, 8); // Cap display decimals at 8 for UX
+      const decimalPattern = new RegExp(`^\\d+(\\.\\d{0,${maxDecimals}})?$`);
+      const isValid = amount === '' || decimalPattern.test(amount);
 
-    const numDecimalAmount = Number(amount);
+      if (!isValid) return;
 
-    // Convert to raw quantity for validation against MAX_SAFE_QUANTITY
-    const rawAmount = getRawQuantity(numDecimalAmount, decimals);
-    if (rawAmount > MAX_SAFE_QUANTITY) {
-      toast.error(`Quantity exceeds maximum safe value`);
-      return;
-    }
+      const numDecimalAmount = Number(amount);
 
-    // Cap at available quantity (work in raw units to avoid rounding issues)
-    if (rawAmount > ft.quantity) {
-      // Cap to available raw quantity, then convert back to decimal for display
-      const cappedRawAmount = ft.quantity;
-      const cappedDecimalAmount = getDecimalAdjustedQuantity(cappedRawAmount, decimals);
-      // Truncate to display precision (max 8 decimals) without rounding up
-      const displayDecimals = Math.min(decimals, 8);
-      const multiplier = Math.pow(10, displayDecimals);
-      const truncatedAmount = Math.floor(cappedDecimalAmount * multiplier) / multiplier;
-      amount = truncatedAmount.toFixed(displayDecimals);
-    }
-
-    setSelectedAmount(prev => ({
-      ...prev,
-      [ft.tokenId]: amount,
-    }));
-
-    setSelectedNFTs(prevSelected => {
-      const existingIndex = prevSelected.findIndex(nft => nft.tokenId === ft.tokenId);
-
-      if (amount && amount !== '0') {
-        if (existingIndex >= 0) {
-          return prevSelected.map(item => (item.tokenId === ft.tokenId ? { ...item, amount } : item));
-        } else {
-          const ftCount = prevSelected.filter(a => a.isFungibleToken).length;
-          if (ftCount >= MAX_FT_PER_TRANSACTION) {
-            return prevSelected;
-          }
-          return [...prevSelected, { ...ft, amount }];
-        }
-      } else {
-        if (existingIndex >= 0) {
-          return prevSelected.filter(item => item.tokenId !== ft.tokenId);
-        }
-        return prevSelected;
+      // Convert to raw quantity for validation against MAX_SAFE_QUANTITY
+      const rawAmount = getRawQuantity(numDecimalAmount, decimals);
+      if (rawAmount > MAX_SAFE_QUANTITY) {
+        toast.error(`Quantity exceeds maximum safe value`);
+        return;
       }
-    });
-  }, []);
+
+      // Check whitelist cap limits (if in contribution mode, not expansion)
+      if (!isExpansionMode && assetsWhitelist?.length) {
+        const ftPolicyId = ft.metadata?.policyId;
+        const whitelistItem = assetsWhitelist.find(item => item.policyId === ftPolicyId);
+
+        if (whitelistItem) {
+          const contributedAssets = vaultAssetsData?.data?.items || [];
+          const contributionStatus = getContributionStatus(assetsWhitelist, contributedAssets);
+          const policyStatus = contributionStatus.find(status => status.policyId === ftPolicyId);
+
+          if (policyStatus) {
+            // Check against remaining capacity
+            if (rawAmount > policyStatus.remainingCapacity) {
+              const maxAllowed = getDecimalAdjustedQuantity(policyStatus.remainingCapacity, decimals);
+              const displayDecimals = Math.min(decimals, 8);
+              toast.error(
+                `Cannot contribute more than ${maxAllowed.toFixed(displayDecimals)} tokens. Vault cap: ${getDecimalAdjustedQuantity(policyStatus.countCapMax, decimals).toFixed(displayDecimals)}, Already contributed: ${getDecimalAdjustedQuantity(policyStatus.currentContributions, decimals).toFixed(displayDecimals)}`
+              );
+              return;
+            }
+          }
+        }
+      }
+
+      // Cap at available quantity (work in raw units to avoid rounding issues)
+      if (rawAmount > ft.quantity) {
+        // Cap to available raw quantity, then convert back to decimal for display
+        const cappedRawAmount = ft.quantity;
+        const cappedDecimalAmount = getDecimalAdjustedQuantity(cappedRawAmount, decimals);
+        // Truncate to display precision (max 8 decimals) without rounding up
+        const displayDecimals = Math.min(decimals, 8);
+        const multiplier = Math.pow(10, displayDecimals);
+        const truncatedAmount = Math.floor(cappedDecimalAmount * multiplier) / multiplier;
+        amount = truncatedAmount.toFixed(displayDecimals);
+      }
+
+      setSelectedAmount(prev => ({
+        ...prev,
+        [ft.tokenId]: amount,
+      }));
+
+      setSelectedNFTs(prevSelected => {
+        const existingIndex = prevSelected.findIndex(nft => nft.tokenId === ft.tokenId);
+
+        if (amount && amount !== '0') {
+          if (existingIndex >= 0) {
+            return prevSelected.map(item => (item.tokenId === ft.tokenId ? { ...item, amount } : item));
+          } else {
+            const ftCount = prevSelected.filter(a => a.isFungibleToken).length;
+            if (ftCount >= MAX_FT_PER_TRANSACTION) {
+              return prevSelected;
+            }
+            return [...prevSelected, { ...ft, amount }];
+          }
+        } else {
+          if (existingIndex >= 0) {
+            return prevSelected.filter(item => item.tokenId !== ft.tokenId);
+          }
+          return prevSelected;
+        }
+      });
+    },
+    [isExpansionMode, assetsWhitelist, vaultAssetsData]
+  );
 
   const removeNFT = tokenId => {
     setSelectedNFTs(selectedNFTs.filter(nft => nft.tokenId !== tokenId));

--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -198,8 +198,6 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
       // Get decimals from metadata, default to 6 if not specified
       const decimals = ft.metadata?.decimals ?? 6;
 
-      console.log(ft, amount, decimals);
-
       // Allow empty string or valid decimal numbers with decimals matching the token
       const maxDecimals = Math.min(decimals, 8); // Cap display decimals at 8 for UX
       const decimalPattern = new RegExp(`^\\d+(\\.\\d{0,${maxDecimals}})?$`);

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -16,7 +16,7 @@ export const LavaWhitelistWithCaps = ({
   setWhitelist,
   maxItems = 10,
   errors = {},
-  maxCapValue = 1000000000,
+  maxCapValue = 1000000000000, // 1 Trillion
 }) => {
   const [showDropdown, setShowDropdown] = useState({});
   const [searchResults, setSearchResults] = useState({});

--- a/src/components/vaults/steps/ConfigureVault.jsx
+++ b/src/components/vaults/steps/ConfigureVault.jsx
@@ -136,7 +136,6 @@ export const ConfigureVault = ({
             whitelist={data.assetsWhitelist || []}
             errors={errors}
             vaultType={data.type}
-            maxCapValue={1000000000}
           />
           {errors.assetsWhitelist && <p className="text-red-600 mt-2 text-sm">{errors.assetsWhitelist}</p>}
         </div>


### PR DESCRIPTION
This pull request mainly introduces stricter validation for token contributions based on whitelist cap limits and increases the maximum cap value for whitelisted assets. The most important changes are grouped below:

### Contribution validation improvements

* Added logic in `ContributeModal.jsx` to enforce whitelist cap limits when users contribute tokens (except in expansion mode). If a user attempts to contribute more than the allowed cap, an error message is shown indicating the vault cap and already contributed amount.
* Updated the dependencies of the `handleFTAmountChange` callback to ensure it reacts to changes in `isExpansionMode`, `assetsWhitelist`, and `vaultAssetsData`.

### Whitelist cap configuration

* Increased the default `maxCapValue` for whitelisted assets in `LavaWhitelistWithCaps.jsx` from 1 billion to 1 trillion tokens, allowing for larger caps.
* Removed the hardcoded `maxCapValue` prop in `ConfigureVault.jsx` to rely on the new default in `LavaWhitelistWithCaps`.

### Code quality

* Improved the `handleFTAmountChange` function in `ContributeModal.jsx` by clarifying the retrieval of decimals from token metadata, defaulting to 6 if unspecified.