### PR TITLE
Improve error handling for vault launch and draft saving

### DIFF
--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -613,8 +613,8 @@ export const CreateVaultForm = ({ vault, setVault }) => {
         }
 
         if (!handleServerFieldErrors(err)) {
-          toast.error('Failed to launch vault, it will be saved as draft');
-          await saveDraft();
+          toast.error('Failed to launch vault. Your progress has been saved as a draft.');
+          await navigate({ to: '/profile', search: { tab: 'draft' } });
         }
       } finally {
         setIsSubmitting(false);


### PR DESCRIPTION
This pull request updates the error handling flow in the `CreateVaultForm` component to improve the user experience when vault creation fails. Now, instead of simply saving the vault as a draft, the user is redirected to their profile's draft tab with a clearer error message.

Error handling and user flow improvements:

* Updated the error notification message for failed vault creation to be more informative and user-friendly.
* Changed the post-error action from saving a draft locally to redirecting the user to the `/profile` page with the `draft` tab selected, ensuring users can easily find and manage their draft vaults.