### PR TITLE
Refactor handleFTAmountChange for improved validation

### DIFF
--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -193,91 +193,64 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     });
   }, []);
 
-  const handleFTAmountChange = useCallback(
-    (ft, amount) => {
-      // Get decimals from metadata, default to 6 if not specified
-      const decimals = ft.metadata?.decimals ?? 6;
+  const handleFTAmountChange = useCallback((ft, amount) => {
+    // Get decimals from metadata, default to 6 if not specified
+    const decimals = ft.metadata?.decimals ?? 6;
 
-      // Allow empty string or valid decimal numbers with decimals matching the token
-      const maxDecimals = Math.min(decimals, 8); // Cap display decimals at 8 for UX
-      const decimalPattern = new RegExp(`^\\d+(\\.\\d{0,${maxDecimals}})?$`);
-      const isValid = amount === '' || decimalPattern.test(amount);
+    // Allow empty string or valid decimal numbers with decimals matching the token
+    const maxDecimals = Math.min(decimals, 8); // Cap display decimals at 8 for UX
+    const decimalPattern = new RegExp(`^\\d+(\\.\\d{0,${maxDecimals}})?$`);
+    const isValid = amount === '' || decimalPattern.test(amount);
 
-      if (!isValid) return;
+    if (!isValid) return;
 
-      const numDecimalAmount = Number(amount);
+    const numDecimalAmount = Number(amount);
 
-      // Convert to raw quantity for validation against MAX_SAFE_QUANTITY
-      const rawAmount = getRawQuantity(numDecimalAmount, decimals);
-      if (rawAmount > MAX_SAFE_QUANTITY) {
-        toast.error(`Quantity exceeds maximum safe value`);
-        return;
-      }
+    // Convert to raw quantity for validation against MAX_SAFE_QUANTITY
+    const rawAmount = getRawQuantity(numDecimalAmount, decimals);
+    if (rawAmount > MAX_SAFE_QUANTITY) {
+      toast.error(`Quantity exceeds maximum safe value`);
+      return;
+    }
 
-      // Check whitelist cap limits (if in contribution mode, not expansion)
-      if (!isExpansionMode && assetsWhitelist?.length) {
-        const ftPolicyId = ft.metadata?.policyId;
-        const whitelistItem = assetsWhitelist.find(item => item.policyId === ftPolicyId);
+    // Cap at available quantity (work in raw units to avoid rounding issues)
+    if (rawAmount > ft.quantity) {
+      // Cap to available raw quantity, then convert back to decimal for display
+      const cappedRawAmount = ft.quantity;
+      const cappedDecimalAmount = getDecimalAdjustedQuantity(cappedRawAmount, decimals);
+      // Truncate to display precision (max 8 decimals) without rounding up
+      const displayDecimals = Math.min(decimals, 8);
+      const multiplier = Math.pow(10, displayDecimals);
+      const truncatedAmount = Math.floor(cappedDecimalAmount * multiplier) / multiplier;
+      amount = truncatedAmount.toFixed(displayDecimals);
+    }
 
-        if (whitelistItem) {
-          const contributedAssets = vaultAssetsData?.data?.items || [];
-          const contributionStatus = getContributionStatus(assetsWhitelist, contributedAssets);
-          const policyStatus = contributionStatus.find(status => status.policyId === ftPolicyId);
+    setSelectedAmount(prev => ({
+      ...prev,
+      [ft.tokenId]: amount,
+    }));
 
-          if (policyStatus) {
-            // Check against remaining capacity
-            if (rawAmount > policyStatus.remainingCapacity) {
-              const maxAllowed = getDecimalAdjustedQuantity(policyStatus.remainingCapacity, decimals);
-              const displayDecimals = Math.min(decimals, 8);
-              toast.error(
-                `Cannot contribute more than ${maxAllowed.toFixed(displayDecimals)} tokens. Vault cap: ${getDecimalAdjustedQuantity(policyStatus.countCapMax, decimals).toFixed(displayDecimals)}, Already contributed: ${getDecimalAdjustedQuantity(policyStatus.currentContributions, decimals).toFixed(displayDecimals)}`
-              );
-              return;
-            }
-          }
-        }
-      }
+    setSelectedNFTs(prevSelected => {
+      const existingIndex = prevSelected.findIndex(nft => nft.tokenId === ft.tokenId);
 
-      // Cap at available quantity (work in raw units to avoid rounding issues)
-      if (rawAmount > ft.quantity) {
-        // Cap to available raw quantity, then convert back to decimal for display
-        const cappedRawAmount = ft.quantity;
-        const cappedDecimalAmount = getDecimalAdjustedQuantity(cappedRawAmount, decimals);
-        // Truncate to display precision (max 8 decimals) without rounding up
-        const displayDecimals = Math.min(decimals, 8);
-        const multiplier = Math.pow(10, displayDecimals);
-        const truncatedAmount = Math.floor(cappedDecimalAmount * multiplier) / multiplier;
-        amount = truncatedAmount.toFixed(displayDecimals);
-      }
-
-      setSelectedAmount(prev => ({
-        ...prev,
-        [ft.tokenId]: amount,
-      }));
-
-      setSelectedNFTs(prevSelected => {
-        const existingIndex = prevSelected.findIndex(nft => nft.tokenId === ft.tokenId);
-
-        if (amount && amount !== '0') {
-          if (existingIndex >= 0) {
-            return prevSelected.map(item => (item.tokenId === ft.tokenId ? { ...item, amount } : item));
-          } else {
-            const ftCount = prevSelected.filter(a => a.isFungibleToken).length;
-            if (ftCount >= MAX_FT_PER_TRANSACTION) {
-              return prevSelected;
-            }
-            return [...prevSelected, { ...ft, amount }];
-          }
+      if (amount && amount !== '0') {
+        if (existingIndex >= 0) {
+          return prevSelected.map(item => (item.tokenId === ft.tokenId ? { ...item, amount } : item));
         } else {
-          if (existingIndex >= 0) {
-            return prevSelected.filter(item => item.tokenId !== ft.tokenId);
+          const ftCount = prevSelected.filter(a => a.isFungibleToken).length;
+          if (ftCount >= MAX_FT_PER_TRANSACTION) {
+            return prevSelected;
           }
-          return prevSelected;
+          return [...prevSelected, { ...ft, amount }];
         }
-      });
-    },
-    [isExpansionMode, assetsWhitelist, vaultAssetsData]
-  );
+      } else {
+        if (existingIndex >= 0) {
+          return prevSelected.filter(item => item.tokenId !== ft.tokenId);
+        }
+        return prevSelected;
+      }
+    });
+  }, []);
 
   const removeNFT = tokenId => {
     setSelectedNFTs(selectedNFTs.filter(nft => nft.tokenId !== tokenId));
@@ -427,7 +400,7 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
                   : 'Total estimated value of your selected assets. Final value is calculated at the end of the contribution window.'
               }
             />
-            {vault.protocolContributorsFeeAda > 0 && (
+            {isExpansionMode && vault.protocolContributorsFeeAda > 0 && (
               <MetricCard
                 label="Protocol Fee"
                 value={`${currencySymbol}${isAda ? vault.protocolContributorsFeeAda.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : vault.protocolContributorsFeeUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}


### PR DESCRIPTION
This pull request updates the `ContributeModal` component to simplify logic for handling fungible token (FT) amount changes and to ensure protocol fees are only shown in expansion mode. The main changes remove whitelist cap checks from the FT amount handler and adjust the display of protocol fees.

**Logic simplification:**
- Removed whitelist cap enforcement when entering FT amounts, streamlining the contribution flow and reducing unnecessary checks in the `handleFTAmountChange` callback. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL217-L240) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL278-R253)
- Cleaned up the dependencies and formatting of the `handleFTAmountChange` callback for clarity and maintainability. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL196-R196) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL278-R253)

**UI adjustments:**
- Updated the protocol fee display so that the "Protocol Fee" metric is only shown when the modal is in expansion mode, preventing confusion for contributors in other modes.