### PR TITLE
Refactor wallet balance loading and clean up asset imports

### DIFF
--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -1,7 +1,6 @@
 import { X, Plus, ChevronDown, ChevronUp, Loader2, ShieldCheck, ShieldAlert } from 'lucide-react';
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
-import toast from 'react-hot-toast';
 
 import { Button } from '@/components/ui/button';
 import { LavaInput } from '@/components/shared/LavaInput';
@@ -25,8 +24,7 @@ export const LavaWhitelistWithCaps = ({
   const searchTimers = useRef({});
   const wallet = useWallet('handler', 'isConnected', 'balanceAda', 'changeAddressBech32');
 
-  const { data, hasMore, isLoadingMore, loadMore, searchPolicies, lookupPolicies, allPolicies, isBalanceLoaded } =
-    useAssets();
+  const { data, hasMore, isLoadingMore, loadMore, searchPolicies, lookupPolicies } = useAssets();
 
   const walletPolicyIds = data?.data || [];
 

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -66,33 +66,6 @@ export const LavaWhitelistWithCaps = ({
     );
   }, [whitelist, setWhitelist]);
 
-  // When the wallet balance first loads, remove any whitelist items whose policy ID
-  // is no longer held by the user (e.g. they spent those NFTs since saving the draft).
-  // We only run this once per mount (tracked by hasFilteredStaleRef) and only after
-  // there are actual whitelist items to check (wallet may load before draft data).
-  const hasFilteredStaleRef = useRef(false);
-  useEffect(() => {
-    if (!isBalanceLoaded) return;
-    if (whitelist.length === 0) return;
-    if (hasFilteredStaleRef.current) return;
-    hasFilteredStaleRef.current = true;
-
-    const walletPolicyIdSet = new Set(allPolicies.map(p => p.policyId));
-
-    const filtered = whitelist.filter(
-      item => !item?.policyId || !/^[0-9a-fA-F]{56}$/.test(item.policyId) || walletPolicyIdSet.has(item.policyId)
-    );
-
-    if (filtered.length < whitelist.length) {
-      const removedCount = whitelist.length - filtered.length;
-      setWhitelist(filtered);
-      toast(
-        `${removedCount} asset${removedCount > 1 ? 's were' : ' was'} removed from the whitelist because ${removedCount > 1 ? "they're" : "it's"} no longer in your wallet.`,
-        { icon: '⚠️', duration: 5000 }
-      );
-    }
-  }, [isBalanceLoaded, allPolicies, whitelist, setWhitelist]);
-
   const handleScroll = useCallback(
     (e, uniqueId) => {
       const asset = whitelist.find(item => item.uniqueId === uniqueId);


### PR DESCRIPTION
This pull request simplifies the `LavaWhitelistWithCaps` component by removing logic related to filtering out whitelist items that are no longer present in the user's wallet. It also removes the use of the `react-hot-toast` notification library and cleans up related state management.

**Removed wallet balance-dependent filtering and notifications:**

* Removed the effect that filtered out whitelist items whose policy IDs are no longer held by the user, along with the associated state tracking (`hasFilteredStaleRef`).
* Removed the use of `allPolicies` and `isBalanceLoaded` from the `useAssets()` hook, as they are no longer needed.
* Removed the import of the `react-hot-toast` library, since toast notifications are no longer used.