### PR TITLE
ADDED: partner badge for vault

### DIFF
--- a/src/components/shared/GoldenVerifiedBadge.tsx
+++ b/src/components/shared/GoldenVerifiedBadge.tsx
@@ -1,0 +1,101 @@
+import { useId } from 'react';
+
+import { HoverHelp } from '@/components/shared/HoverHelp';
+
+type BadgeSize = 'sm' | 'md' | 'lg';
+
+const SIZE_CLASS: Record<BadgeSize, string> = {
+  sm: 'h-3.5 w-3.5',
+  md: 'h-4 w-4',
+  lg: 'h-5 w-5',
+};
+
+/** Scalloped circle — same silhouette as Instagram's verified badge */
+const buildScallopedPath = (cx: number, cy: number, outerR: number, innerR: number, points = 12) => {
+  const segments = points * 2;
+  let path = '';
+
+  for (let i = 0; i < segments; i += 1) {
+    const angle = (Math.PI * i) / points - Math.PI / 2;
+    const radius = i % 2 === 0 ? outerR : innerR;
+    const x = cx + radius * Math.cos(angle);
+    const y = cy + radius * Math.sin(angle);
+    path += `${i === 0 ? 'M' : 'L'}${x.toFixed(2)},${y.toFixed(2)}`;
+  }
+
+  return `${path}Z`;
+};
+
+const BADGE_PATH = buildScallopedPath(12, 12, 11.35, 9.85);
+
+type VerifiedIconProps = {
+  size?: BadgeSize;
+  className?: string;
+  gradientId: string;
+};
+
+const VerifiedIcon = ({ size = 'md', className = '', gradientId }: VerifiedIconProps) => (
+  <svg viewBox="0 0 24 24" className={`shrink-0 ${SIZE_CLASS[size]} ${className}`} aria-hidden="true">
+    <defs>
+      <linearGradient id={gradientId} x1="5" y1="3" x2="19" y2="21" gradientUnits="userSpaceOnUse">
+        <stop offset="0%" stopColor="#FFF8D6" />
+        <stop offset="38%" stopColor="#F5C518" />
+        <stop offset="72%" stopColor="#D4A017" />
+        <stop offset="100%" stopColor="#9A7209" />
+      </linearGradient>
+    </defs>
+    <path d={BADGE_PATH} fill={`url(#${gradientId})`} />
+    <path d={BADGE_PATH} fill="none" stroke="rgba(255,255,255,0.28)" strokeWidth="0.6" />
+    <ellipse cx="9.2" cy="8.4" rx="3.6" ry="2.2" fill="rgba(255,255,255,0.2)" />
+    <path
+      d="M7.1 12.15l2.75 2.75 7.05-7.35"
+      stroke="white"
+      strokeWidth="2.35"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);
+
+export type GoldenVerifiedBadgeProps = {
+  /** Tooltip text on hover (omit for icon-only, no tooltip) */
+  hint?: string;
+  size?: BadgeSize;
+  className?: string;
+  /** Accessible name */
+  label?: string;
+};
+
+export const GoldenVerifiedBadge = ({
+  hint,
+  size = 'md',
+  className = '',
+  label = 'Verified',
+}: GoldenVerifiedBadgeProps) => {
+  const gradientId = useId().replace(/:/g, '');
+  const icon = <VerifiedIcon size={size} className={className} gradientId={gradientId} />;
+
+  if (!hint) {
+    return (
+      <span className="inline-flex align-middle" role="img" aria-label={label}>
+        {icon}
+      </span>
+    );
+  }
+
+  return (
+    <HoverHelp hint={hint} variant="icon" className="inline-flex align-middle group">
+      <span
+        tabIndex={0}
+        role="img"
+        aria-label={label}
+        className="inline-flex cursor-help rounded-full transition-transform duration-150 ease-out group-hover:scale-110 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-amber-400/70 focus-visible:ring-offset-1 focus-visible:ring-offset-transparent"
+      >
+        {icon}
+      </span>
+    </HoverHelp>
+  );
+};
+
+export const OFFICIAL_PARTNER_BADGE_HINT = 'Official L4VA partner vault — verified and supported by the L4VA team.';

--- a/src/components/shared/HoverHelp.d.ts
+++ b/src/components/shared/HoverHelp.d.ts
@@ -1,0 +1,11 @@
+import type { ReactNode, ReactElement } from 'react';
+
+export type HoverHelpProps = {
+  hint: string;
+  className?: string;
+  variant?: 'help' | 'icon';
+  children?: ReactNode;
+  wrap?: boolean;
+};
+
+export declare const HoverHelp: (props: HoverHelpProps) => ReactElement;

--- a/src/components/shared/HoverHelp.jsx
+++ b/src/components/shared/HoverHelp.jsx
@@ -54,6 +54,12 @@ export const HoverHelp = ({ hint, className = '', variant = 'help', children = n
     setIsVisible(true);
   };
 
+  const hideIfFocusLeft = e => {
+    if (!triggerRef.current?.contains(e.relatedTarget)) {
+      setIsVisible(false);
+    }
+  };
+
   useLayoutEffect(() => {
     if (!isVisible) return;
 
@@ -94,8 +100,10 @@ export const HoverHelp = ({ hint, className = '', variant = 'help', children = n
       className={`inline-flex ${isIconVariant ? '' : 'font-normal'} ${className}`}
       onMouseEnter={show}
       onMouseLeave={() => setIsVisible(false)}
-      onFocus={show}
-      onBlur={() => setIsVisible(false)}
+      onFocus={isIconVariant ? undefined : show}
+      onBlur={isIconVariant ? undefined : () => setIsVisible(false)}
+      onFocusIn={isIconVariant ? show : undefined}
+      onFocusOut={isIconVariant ? hideIfFocusLeft : undefined}
       tabIndex={isIconVariant ? -1 : 0}
       role={isIconVariant ? undefined : 'button'}
     >

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -13,6 +13,7 @@ import {
 } from '@/components/vaults/constants/vaults.constants';
 import PrimaryButton from '@/components/shared/PrimaryButton';
 import { Chip } from '@/components/shared/Chip';
+import { GoldenVerifiedBadge, OFFICIAL_PARTNER_BADGE_HINT } from '@/components/shared/GoldenVerifiedBadge';
 import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
 const VaultContribution = lazy(() =>
   import('@/components/vault-profile/VaultContribution')
@@ -453,7 +454,12 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
     <div className="flex justify-between items-start w-full mb-6">
       <div className="flex flex-col w-full">
         <div className="flex w-full flex-col items-start gap-3 mb-3 sm:flex-row sm:justify-between sm:items-center">
-          <h1 className="text-2xl font-bold break-words">{vault.name}</h1>
+          <div className="flex items-center gap-2 min-w-0">
+            <h1 className="text-2xl font-bold break-words">{vault.name}</h1>
+            {vault.isOfficialPartner && (
+              <GoldenVerifiedBadge hint={OFFICIAL_PARTNER_BADGE_HINT} label="Official L4VA partner" />
+            )}
+          </div>
           <div className="flex gap-2 items-center">
             {isAuthenticated && (
               <div className="group relative">

--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -2,6 +2,7 @@ import { Link } from '@tanstack/react-router';
 import { useMemo } from 'react';
 
 import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
+import { GoldenVerifiedBadge, OFFICIAL_PARTNER_BADGE_HINT } from '@/components/shared/GoldenVerifiedBadge';
 import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 import { formatCompactNumber, formatString } from '@/utils/core.utils';
 import { VaultShortResponse } from '@/utils/types';
@@ -63,7 +64,12 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
               </div>
             )}
             <div>
-              <h2 className="font-bold">{name || 'No name'}</h2>
+              <div className="flex items-center gap-1.5">
+                <h2 className="font-bold">{name || 'No name'}</h2>
+                {vault.isOfficialPartner && (
+                  <GoldenVerifiedBadge size="sm" hint={OFFICIAL_PARTNER_BADGE_HINT} label="Official L4VA partner" />
+                )}
+              </div>
               <p className="text-sm text-dark-100 line-clamp-3">{description || 'No description'}</p>
             </div>
           </div>

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -117,6 +117,7 @@ export interface IVault {
   socialLinks?: ILink[];
   assetsWhitelist?: IAssetsWhitelist[];
   contributorWhitelist?: IContributorWhitelist[];
+  isOfficialPartner?: boolean;
 }
 
 export interface ITag {
@@ -202,6 +203,7 @@ export interface VaultShortResponse {
   socialLinks?: ILink[];
   ftTokenImg?: string;
   vaultTokenTicker?: string;
+  isOfficialPartner?: boolean;
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
This pull request introduces a new "Golden Verified Badge" component to visually indicate official L4VA partner vaults across the application. The badge is displayed in both the vault profile view and vault cards when the `isOfficialPartner` flag is set on a vault. The changes also include the addition of the `isOfficialPartner` property to the relevant vault types to support this feature.

**New Golden Verified Badge feature:**

- Added a reusable `GoldenVerifiedBadge` component with a custom SVG and hover tooltip, along with a standardized hint message (`OFFICIAL_PARTNER_BADGE_HINT`). (`src/components/shared/GoldenVerifiedBadge.tsx`)
- Display the badge next to the vault name in `VaultProfileView` when `isOfficialPartner` is true. (`src/components/vault-profile/VaultProfileView.jsx`) [[1]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935R16) [[2]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935R457-R462)
- Display the badge next to the vault name in `VaultCard` when `isOfficialPartner` is true. (`src/components/vaults/VaultCard.tsx`) [[1]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffR5) [[2]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffR67-R72)

**Type and data model updates:**

- Added the optional `isOfficialPartner` boolean property to both `IVault` and `VaultShortResponse` interfaces to support the new badge logic. (`src/utils/types.ts`) [[1]](diffhunk://#diff-98a58367e6df376c04f7d50445cf8b648654b7533801565e9f215037c219e5edR120) [[2]](diffhunk://#diff-98a58367e6df376c04f7d50445cf8b648654b7533801565e9f215037c219e5edR206)