### PR TITLE
ADDED: new validation for vaultTokenTicker

### DIFF
--- a/src/components/modals/EditUpcomingVaultModal.jsx
+++ b/src/components/modals/EditUpcomingVaultModal.jsx
@@ -134,7 +134,7 @@ export const EditUpcomingVaultModal = ({ isOpen = true, onClose, vault }) => {
   };
 
   const buildPayload = () => ({
-    vaultTokenTicker: formData.vaultTokenTicker ? String(formData.vaultTokenTicker).toUpperCase() : null,
+    vaultTokenTicker: formData.vaultTokenTicker ? String(formData.vaultTokenTicker) : null,
     vaultImage: formData.vaultImage || null,
     ftTokenImg: formData.ftTokenImg || null,
     description: formData.description || null,
@@ -220,9 +220,7 @@ export const EditUpcomingVaultModal = ({ isOpen = true, onClose, vault }) => {
             placeholder="Add ticker"
             value={formData.vaultTokenTicker}
             onChange={value => {
-              const normalized = String(value || '')
-                .toUpperCase()
-                .replace(/[^A-Z0-9]/g, '');
+              const normalized = String(value || '').replace(/[^A-Za-z0-9]/g, '');
               setFormData(prev => ({ ...prev, vaultTokenTicker: normalized }));
               clearFieldError('vaultTokenTicker');
             }}

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -187,7 +187,7 @@ export const vaultSchema = yup.object({
   privacy: yup.string().required('Privacy setting is required'),
   vaultTokenTicker: yup
     .string()
-    .matches(/^[A-Z0-9]{1,9}$/, 'Ticker must be 1-9 uppercase letters or numbers')
+    .matches(/^[A-Za-z0-9]{1,9}$/, 'Ticker must be 1-9 letters or numbers')
     .nullable(),
   description: yup.string().max(500, 'Description must be less than 500 characters').optional(),
   tokenDescription: yup.string().max(300, 'Token description must be less than 300 characters').optional(),
@@ -456,7 +456,7 @@ export const vaultSchema = yup.object({
 export const editUpcomingVaultSchema = yup.object({
   vaultTokenTicker: yup
     .string()
-    .matches(/^[A-Z0-9]{1,9}$/, 'Ticker must be 1-9 uppercase letters or numbers')
+    .matches(/^[A-Za-z0-9]{1,9}$/, 'Ticker must be 1-9 letters or numbers')
     .required('Ticker is required'),
   vaultImage: yup.string().required('Vault image is required'),
   ftTokenImg: yup.string().required('Token image is required'),


### PR DESCRIPTION
This pull request updates the validation rules for the `vaultTokenTicker` field in the vault form schemas to allow both uppercase and lowercase letters, in addition to numbers. Previously, only uppercase letters and numbers were permitted. This change improves flexibility for users when entering ticker values.

Form validation updates:

* Relaxed the `vaultTokenTicker` validation in both `vaultSchema` and `editUpcomingVaultSchema` to accept 1-9 characters consisting of any letter (uppercase or lowercase) or number, instead of only uppercase letters and numbers. [[1]](diffhunk://#diff-206ab7ae5fd10ce2144d5799601b84cc60a42b1119b3fa9414e7adfe0534cd56L190-R190) [[2]](diffhunk://#diff-206ab7ae5fd10ce2144d5799601b84cc60a42b1119b3fa9414e7adfe0534cd56L459-R459)