### PR TITLE
ADDED: staking navigation button for rewards

### DIFF
--- a/src/components/rewards/AlignmentBonusDisplay.jsx
+++ b/src/components/rewards/AlignmentBonusDisplay.jsx
@@ -1,4 +1,5 @@
-import { Check, Sparkles, X } from 'lucide-react';
+import { Check, ChevronRight, Sparkles, X } from 'lucide-react';
+import { useNavigate } from '@tanstack/react-router';
 
 import { HoverHelp } from '@/components/shared/HoverHelp';
 
@@ -15,6 +16,8 @@ const ORACLE_TIERS = [
 
 const ALIGNMENT_HINT = `Boost your protocol rewards by up to 20%. Stack multiple bonuses for maximum multiplier.`;
 
+const ORACLE_VAULT_ID = '5ac2ac4f-9079-40cb-94ae-a265bfba3bcd';
+
 const getOracleTier = balance => {
   for (const tier of ORACLE_TIERS) {
     if (balance >= tier.min) return tier;
@@ -23,6 +26,17 @@ const getOracleTier = balance => {
 };
 
 export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
+  const navigate = useNavigate();
+
+  const handleItemClick = item => {
+    if (item.vaultId) {
+      navigate({ to: `/vaults/${item.vaultId}` });
+      return;
+    }
+
+    navigate({ to: '/profile', search: { section: 'staking' } });
+  };
+
   if (!alignmentData && !isLoading) return null;
 
   const bonuses = alignmentData?.bonuses || {};
@@ -39,6 +53,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
   const bonusItems = [
     {
       label: 'L4VA Staking',
+      clickable: true,
       requirement: `Stake at least ${l4vaBonus.requiredAmount?.toLocaleString() || '100,000'} L4VA`,
       bonus: l4vaBonus.bonusPercent || 5,
       achieved: l4vaBonus.achieved,
@@ -49,6 +64,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
     },
     {
       label: 'VLRM Staking',
+      clickable: true,
       requirement: `Stake at least ${vlrmBonus.requiredAmount?.toLocaleString() || '20,000'} VLRM`,
       bonus: vlrmBonus.bonusPercent || 5,
       achieved: vlrmBonus.achieved,
@@ -59,6 +75,8 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
     },
     {
       label: 'ORACLE Holding',
+      clickable: true,
+      vaultId: ORACLE_VAULT_ID,
       requirement: oracleTier ? oracleTier.label : 'Hold at least 100 ORACLE',
       bonus: oracleBonus.bonusPercent || 0,
       achieved: oracleBonus.achieved,
@@ -132,8 +150,25 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
               </div>
               <div className="flex-1 min-w-0">
                 <div className="flex items-center justify-between gap-2 mb-1">
-                  <span className={`font-medium ${item.achieved ? 'text-white' : 'text-steel-400'}`}>{item.label}</span>
-                  <span className={`text-sm font-semibold ${item.achieved ? 'text-orange-500' : 'text-steel-500'}`}>
+                  {item.clickable ? (
+                    <button
+                      type="button"
+                      onClick={() => handleItemClick(item)}
+                      className={`group flex items-center gap-1 font-medium transition-colors text-left ${
+                        item.achieved ? 'text-white hover:text-orange-400' : 'text-steel-400 hover:text-orange-500'
+                      }`}
+                    >
+                      <span>{item.label}</span>
+                      <ChevronRight className="w-4 h-4 shrink-0 text-steel-500 transition-colors group-hover:text-orange-500" />
+                    </button>
+                  ) : (
+                    <span className={`font-medium ${item.achieved ? 'text-white' : 'text-steel-400'}`}>
+                      {item.label}
+                    </span>
+                  )}
+                  <span
+                    className={`text-sm font-semibold shrink-0 ${item.achieved ? 'text-orange-500' : 'text-steel-500'}`}
+                  >
                     {item.bonus > 0 ? `+${item.bonus}%` : item.isTiered ? '+0.5% to +5%' : `+${item.bonus}%`}
                   </span>
                 </div>

--- a/src/pages/profile/StakingWidget.tsx
+++ b/src/pages/profile/StakingWidget.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { RefreshCw } from 'lucide-react';
 
 import { LavaTabs } from '@/components/shared/LavaTabs';
@@ -52,7 +52,12 @@ const formatTokenInputValue = (raw: string, maximumFractionDigits: number) => {
 };
 const getTokenMaxFractionDigits = (symbol: string) => (symbol === 'L4VA' ? L4VA_DECIMALS : VLRM_DECIMALS);
 
-export const StakingWidget: React.FC = () => {
+type StakingWidgetProps = {
+  focusOnMount?: boolean;
+};
+
+export const StakingWidget: React.FC<StakingWidgetProps> = ({ focusOnMount = false }) => {
+  const widgetRef = useRef<HTMLDivElement>(null);
   const [tab, setTab] = useState<TabKey>('stake');
   const [vlrmAmountRaw, setVlrmAmountRaw] = useState('');
   const [l4vaAmountRaw, setL4vaAmountRaw] = useState('');
@@ -61,6 +66,29 @@ export const StakingWidget: React.FC = () => {
   const { openModal, updateModal } = useModalControls();
 
   const { vlrmBalance, l4vaBalance, isLoading: isBalanceLoading, refreshBalances } = useStakeBalances();
+
+  useEffect(() => {
+    if (!focusOnMount) return;
+
+    setTab('stake');
+
+    const timer = setTimeout(() => {
+      const element = widgetRef.current;
+      if (!element) return;
+
+      const headerHeight = 72;
+      const additionalOffset = 24;
+      const elementPosition = element.getBoundingClientRect().top + window.pageYOffset;
+      const offsetPosition = elementPosition - headerHeight - additionalOffset;
+
+      window.scrollTo({
+        top: offsetPosition,
+        behavior: 'smooth',
+      });
+    }, 100);
+
+    return () => clearTimeout(timer);
+  }, [focusOnMount]);
 
   const { stake, unstake, harvest, compound, status, isProcessing } = useStakeTransaction();
   const {
@@ -214,7 +242,7 @@ export const StakingWidget: React.FC = () => {
   }, [vlrmAmount, l4vaAmount]);
 
   return (
-    <div className="flex w-full">
+    <div ref={widgetRef} className="flex w-full">
       <div className="w-full rounded-2xl border border-steel-750 bg-steel-950 shadow-[0_20px_60px_-30px_rgba(0,0,0,0.7)]">
         {/* Header */}
         <div className="px-4 sm:px-6 pt-5 sm:pt-6 pb-4">

--- a/src/pages/profile/index.jsx
+++ b/src/pages/profile/index.jsx
@@ -39,7 +39,7 @@ export const Profile = ({ userId, isEditable }) => {
         {!userId && (
           <div className="w-full">
             <div className="grid grid-cols-1 xl:grid-cols-[minmax(0,1fr)_340px] gap-4 xl:gap-6 items-stretch">
-              <StakingWidget />
+              <StakingWidget focusOnMount={search?.section === 'staking'} />
               <ProfileRewardsLinkCard />
             </div>
           </div>

--- a/src/routes/profile/index.jsx
+++ b/src/routes/profile/index.jsx
@@ -21,5 +21,6 @@ export const Route = createFileRoute('/profile/')({
   component: ProfileComponent,
   validateSearch: search => ({
     tab: search?.tab || undefined,
+    section: search?.section || undefined,
   }),
 });


### PR DESCRIPTION
This pull request introduces an improved user experience for navigating to the staking section from the rewards page. Now, clicking the new "Stake" button in the alignment bonus display will route users to the staking widget on the profile page and automatically scroll and focus on that section. The main changes are grouped by theme below.

**Navigation and Routing Enhancements:**

* Added a "Stake" button to the `AlignmentBonusDisplay` component that routes users to the profile page with a query parameter indicating the staking section (`section=staking`). [[1]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dR2-R5) [[2]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dR28-R33) [[3]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dR194-R196)
* Updated the profile route validation to accept an optional `section` parameter in the search query.

**Staking Widget Improvements:**

* Modified `StakingWidget` to accept a `focusOnMount` prop. When this prop is true, the widget automatically scrolls into view and selects the "stake" tab on mount, improving user navigation. [[1]](diffhunk://#diff-4cbcb29965e5bc4282e56bd5dd1c2bad8bd47c0eaccd393bf4fd6f2c3b645f33L55-R60) [[2]](diffhunk://#diff-4cbcb29965e5bc4282e56bd5dd1c2bad8bd47c0eaccd393bf4fd6f2c3b645f33R70-R92) [[3]](diffhunk://#diff-4cbcb29965e5bc4282e56bd5dd1c2bad8bd47c0eaccd393bf4fd6f2c3b645f33L217-R245)
* Updated the profile page to pass `focusOnMount` to `StakingWidget` when the URL search parameter `section` is set to 'staking'.

These changes collectively create a smoother and more intuitive flow for users wanting to stake directly from the rewards section.