### PR TITLE
SET: all proposal modal inputs to steel styles

### DIFF
--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -461,6 +461,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
                     value={proposalStartDate}
                     onChange={value => setProposalStartDate(new Date(value))}
                     error={error && !proposalStartDate}
+                    variant={'steel'}
                   />
                 </div>
                 <div className="flex-1 relative">
@@ -473,6 +474,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
                     minMs={MIN_TIME_FOR_VOTING}
                     maxMs={MAX_TIME_FOR_VOTING}
                     error={error && !proposalDuration}
+                    variant={'steel'}
                   />
                 </div>
               </div>

--- a/src/components/modals/CreateProposalModal/Expansion.jsx
+++ b/src/components/modals/CreateProposalModal/Expansion.jsx
@@ -115,6 +115,7 @@ export default function Expansion({ onDataChange, error, vault }) {
           {!noLimit ? (
             <>
               <LavaIntervalPicker
+                variant={'steel'}
                 value={duration}
                 onChange={setDuration}
                 placeholder="DD:HH:MM"

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -3,9 +3,29 @@ import { useState, useEffect, useRef, useCallback } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
 
 import { Button } from '@/components/ui/button';
-import { LavaInput } from '@/components/shared/LavaInput';
+import { LavaInput, LavaSteelInput } from '@/components/shared/LavaInput';
 import { LavaRadio } from '@/components/shared/LavaRadio';
 import { getVerificationPlatformLabel, useAssets } from '@/hooks/useAssets';
+import { cn } from '@/lib/utils';
+
+const variants = {
+  default: {
+    dropdown:
+      'absolute top-full left-0 right-0 z-50 mt-1 bg-steel-800 border border-steel-600 rounded-lg shadow-lg max-h-64 overflow-y-auto',
+    policyInputClassName: 'pr-20',
+    policyInputStyle: { fontSize: '20px' },
+    addButton: 'border-2 border-white/20 rounded-lg p-2',
+    itemSpacing: 'space-y-6',
+  },
+  steel: {
+    dropdown:
+      'absolute top-full left-0 right-0 z-50 mt-1 bg-steel-850 border border-steel-750 rounded-lg shadow-lg max-h-64 overflow-y-auto',
+    policyInputClassName: 'pr-20',
+    policyInputStyle: undefined,
+    addButton: 'border border-steel-750 rounded-lg p-2',
+    itemSpacing: 'space-y-4',
+  },
+};
 
 export const LavaWhitelistWithCaps = ({
   required = false,
@@ -16,7 +36,23 @@ export const LavaWhitelistWithCaps = ({
   maxItems = 10,
   errors = {},
   maxCapValue = 1000000000000, // 1 Trillion
+  variant = 'default',
 }) => {
+  const styles = variants[variant];
+  const isSteel = variant === 'steel';
+
+  const renderInput = ({ onChange, onBlur, style, ...rest }) => {
+    if (isSteel) {
+      return (
+        <LavaSteelInput
+          {...rest}
+          onChange={onChange ? value => onChange({ target: { value } }) : undefined}
+          onBlur={onBlur}
+        />
+      );
+    }
+    return <LavaInput {...rest} style={style} onChange={onChange} onBlur={onBlur} />;
+  };
   const [showDropdown, setShowDropdown] = useState({});
   const [searchResults, setSearchResults] = useState({});
   const [isSearching, setIsSearching] = useState({});
@@ -386,7 +422,7 @@ export const LavaWhitelistWithCaps = ({
           {label}
         </div>
         <button
-          className={`border-2 border-white/20 rounded-lg p-2 ${whitelist.length >= maxItems ? 'opacity-50 cursor-not-allowed' : ''}`}
+          className={cn(styles.addButton, whitelist.length >= maxItems && 'opacity-50 cursor-not-allowed')}
           disabled={whitelist.length >= maxItems}
           type="button"
           onClick={addNewAsset}
@@ -404,23 +440,23 @@ export const LavaWhitelistWithCaps = ({
           const selectedVerificationLabel = getVerificationPlatformLabel(asset.verificationPlatform);
 
           return (
-            <div key={asset.id || asset.uniqueId} className="space-y-6">
+            <div key={asset.id || asset.uniqueId} className={styles.itemSpacing}>
               <div className="relative" ref={el => (dropdownRefs.current[asset.uniqueId] = el)}>
-                <LavaInput
-                  placeholder={itemPlaceholder}
-                  style={{ fontSize: '20px' }}
-                  value={asset.policyId}
-                  className="pr-20"
-                  onChange={e => handleInputChange(asset.uniqueId, e.target.value)}
-                  onFocus={() => {
+                {renderInput({
+                  placeholder: itemPlaceholder,
+                  style: styles.policyInputStyle,
+                  value: asset.policyId,
+                  className: styles.policyInputClassName,
+                  onChange: e => handleInputChange(asset.uniqueId, e.target.value),
+                  onFocus: () => {
                     if (walletPolicyIds.length > 0 || asset.policyId) {
                       setShowDropdown(prev => ({ ...prev, [asset.uniqueId]: true }));
                       if (asset.policyId) {
                         triggerSearch(asset.uniqueId, asset.policyId);
                       }
                     }
-                  }}
-                />
+                  },
+                })}
                 {wallet.isConnected && walletPolicyIds.length > 0 && (
                   <Button
                     type="button"
@@ -445,10 +481,7 @@ export const LavaWhitelistWithCaps = ({
                   <X className="h-4 w-4" />
                 </Button>
                 {showDropdown[asset.uniqueId] && (
-                  <div
-                    className="absolute top-full left-0 right-0 z-50 mt-1 bg-steel-800 border border-steel-600 rounded-lg shadow-lg max-h-64 overflow-y-auto"
-                    onScroll={e => handleScroll(e, asset.uniqueId)}
-                  >
+                  <div className={styles.dropdown} onScroll={e => handleScroll(e, asset.uniqueId)}>
                     {currentIsSearching ? (
                       <div className="flex items-center justify-center py-6">
                         <Loader2 className="h-5 w-5 animate-spin text-dark-100" />
@@ -506,29 +539,28 @@ export const LavaWhitelistWithCaps = ({
               )}
               <div className="flex gap-4">
                 <div className="flex-1">
-                  <LavaInput
-                    required={true}
-                    label="Min asset cap"
-                    type="text"
-                    pattern="[0-9]*"
-                    style={{ fontSize: '20px' }}
-                    value={asset.countCapMin}
-                    onChange={e => {
+                  {renderInput({
+                    required: true,
+                    label: 'Min asset cap',
+                    type: 'text',
+                    pattern: '[0-9]*',
+                    style: isSteel ? undefined : { fontSize: '20px' },
+                    value: asset.countCapMin,
+                    onChange: e => {
                       const inputValue = e.target.value;
                       const numericValue = Number(inputValue.replace(/,/g, ''));
                       if (inputValue === '' || (!isNaN(numericValue) && numericValue <= maxCapValue)) {
                         updateAsset(asset.uniqueId, 'countCapMin', inputValue);
                       }
-                    }}
-                    onBlur={e =>
+                    },
+                    onBlur: e =>
                       updateAsset(
                         asset.uniqueId,
                         'countCapMin',
                         e.target.value === '' ? 1 : Number(e.target.value.replace(/,/g, ''))
-                      )
-                    }
-                    hint={`Maximum value: ${maxCapValue.toLocaleString()}`}
-                  />
+                      ),
+                    hint: `Maximum value: ${maxCapValue.toLocaleString()}`,
+                  })}
                   {(() => {
                     const index = whitelist.findIndex(item => item.uniqueId === asset.uniqueId);
                     return (
@@ -538,24 +570,24 @@ export const LavaWhitelistWithCaps = ({
                 </div>
 
                 <div className="flex-1">
-                  <LavaInput
-                    required={true}
-                    label="Max asset cap"
-                    value={asset.countCapMax}
-                    onChange={e => {
+                  {renderInput({
+                    required: true,
+                    label: 'Max asset cap',
+                    value: asset.countCapMax,
+                    onChange: e => {
                       const inputValue = e.target.value;
                       const numericValue = Number(inputValue.replace(/,/g, ''));
                       if (inputValue === '' || (!isNaN(numericValue) && numericValue <= maxCapValue)) {
                         updateAsset(asset.uniqueId, 'countCapMax', inputValue);
                       }
-                    }}
-                    onBlur={e => {
+                    },
+                    onBlur: e => {
                       const rawValue = e.target.value === '' ? 1000 : Number(e.target.value.replace(/,/g, ''));
                       const limitedValue = Math.min(rawValue, maxCapValue);
                       updateAsset(asset.uniqueId, 'countCapMax', limitedValue);
-                    }}
-                    hint={`Maximum value: ${maxCapValue.toLocaleString()}`}
-                  />
+                    },
+                    hint: `Maximum value: ${maxCapValue.toLocaleString()}`,
+                  })}
                   {(() => {
                     const index = whitelist.findIndex(item => item.uniqueId === asset.uniqueId);
                     return (
@@ -599,27 +631,26 @@ export const LavaWhitelistWithCaps = ({
 
                 {asset.valuationMethod === 'custom' && !asset.isLpToken && (
                   <div>
-                    <LavaInput
-                      required={true}
-                      label="Custom Price (ADA)"
-                      type="text"
-                      placeholder="Enter price in ADA"
-                      style={{ fontSize: '20px' }}
-                      value={asset.customPriceAda || ''}
-                      onChange={e => {
+                    {renderInput({
+                      required: true,
+                      label: 'Custom Price (ADA)',
+                      type: 'text',
+                      placeholder: 'Enter price in ADA',
+                      style: isSteel ? undefined : { fontSize: '20px' },
+                      value: asset.customPriceAda || '',
+                      onChange: e => {
                         const inputValue = e.target.value;
-                        // Allow decimal numbers
                         if (inputValue === '' || /^\d*\.?\d*$/.test(inputValue)) {
                           updateAsset(asset.uniqueId, 'customPriceAda', inputValue);
                         }
-                      }}
-                      onBlur={e => {
+                      },
+                      onBlur: e => {
                         const rawValue = e.target.value === '' ? 10 : Number(e.target.value.replace(/,/g, ''));
                         const limitedValue = Math.min(rawValue, maxCapValue);
                         updateAsset(asset.uniqueId, 'customPriceAda', limitedValue);
-                      }}
-                      hint="The custom ADA price for this policy"
-                    />
+                      },
+                      hint: 'The custom ADA price for this policy',
+                    })}
                     {(() => {
                       const index = whitelist.findIndex(item => item.uniqueId === asset.uniqueId);
                       return (


### PR DESCRIPTION
This pull request introduces a new `steel` visual variant to several input components, improving UI consistency and flexibility across modals and shared components. It refactors the `LavaWhitelistWithCaps` component to support this new variant, centralizes style management, and updates usages in proposal-related modals.

**Component Theming and Refactoring:**

* Added a `variant` prop (with support for `'steel'` and `'default'`) to the `LavaWhitelistWithCaps` component, centralizing style definitions and enabling easy switching between visual styles. The `renderInput` helper now conditionally renders either `LavaInput` or `LavaSteelInput` based on the variant. [[1]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L6-R28) [[2]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1R39-R55)
* Updated all input fields within `LavaWhitelistWithCaps` to use the new `renderInput` abstraction, ensuring consistent application of the selected variant's styles and logic for all relevant fields (e.g., asset cap inputs, custom price). [[1]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L407-R459) [[2]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L509-R563) [[3]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L541-R590) [[4]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L602-R653)
* Refactored dropdown and button styling in `LavaWhitelistWithCaps` to use the new style definitions from the `variant` system, further unifying the component's appearance. [[1]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L389-R425) [[2]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L448-R484)

**Modal Integration:**

* Updated the `CreateProposalModal` and its `Expansion` subcomponent to pass the `variant="steel"` prop to relevant input components, ensuring the new style is used in proposal creation flows. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R464) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R477) [[3]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR118)