### PR TITLE
CREATED: new ui for ft token item

### DIFF
--- a/src/components/modals/AssetsList/AssetsList.jsx
+++ b/src/components/modals/AssetsList/AssetsList.jsx
@@ -106,7 +106,7 @@ export const AssetsList = ({
         <div className="space-y-1 h-full flex flex-col">
           <div className="flex justify-between text-dark-100 text-sm px-2">
             <span>Asset</span>
-            <span>Policy ID</span>
+            <span>Amount</span>
           </div>
           {isLoading ? (
             <div className="flex items-center justify-center h-32">

--- a/src/components/modals/AssetsList/FTItem.jsx
+++ b/src/components/modals/AssetsList/FTItem.jsx
@@ -1,55 +1,117 @@
+import { Copy, ExternalLink } from 'lucide-react';
+import toast from 'react-hot-toast';
+
 import { LavaSteelInput } from '@/components/shared/LavaInput';
 import { LazyImage } from '@/components/shared/LazyImage';
-import { formatTokenQuantity, formatPolicyId } from '@/utils/core.utils';
+import { HoverHelp } from '@/components/shared/HoverHelp';
+import {
+  formatTokenQuantity,
+  formatTokenQuantityExact,
+  formatPolicyId,
+  getMaxDecimalTokenAmount,
+} from '@/utils/core.utils';
 import { IS_PREPROD } from '@/utils/networkValidation';
 
-export const FTItem = ({ ft, amount, isDisabled, onAmountChange }) => {
-  // Get decimals from metadata, default to 6 if not specified
-  const decimals = ft.metadata?.decimals ?? 6;
+const getPolicyExplorerUrl = policyId =>
+  IS_PREPROD ? `https://preprod.cardanoscan.io/tokenPolicy/${policyId}` : `https://pool.pm/policy/${policyId}`;
+
+const PolicyIdRow = ({ policyId }) => {
+  if (!policyId) return null;
+
+  const handleCopy = e => {
+    e.stopPropagation();
+    navigator.clipboard
+      .writeText(policyId)
+      .then(() => toast.success('Policy ID copied'))
+      .catch(() => toast.error('Failed to copy'));
+  };
 
   return (
-    <div className={`flex items-center gap-2 sm:gap-3 ${isDisabled ? 'opacity-50' : ''}`}>
-      <div className="flex flex-1 items-center justify-between px-2 sm:px-4 py-2 rounded-md gap-2 sm:gap-3 bg-steel-800 overflow-hidden">
-        <div className="flex items-center gap-2 sm:gap-3 flex-1 min-w-0 overflow-hidden">
+    <div className="flex items-center gap-2 min-w-0 border-t border-steel-750/50 pt-2 ml-10 sm:ml-11">
+      <span className="text-[10px] uppercase tracking-wider text-dark-100/70 shrink-0">Policy</span>
+      <span className="font-mono text-xs text-dark-100 truncate flex-1 min-w-0" title={policyId}>
+        {formatPolicyId(policyId, 8, 6)}
+      </span>
+      <div className="flex items-center gap-0.5 shrink-0">
+        <button
+          type="button"
+          onClick={handleCopy}
+          className="p-1 rounded text-dark-100 hover:text-white hover:bg-steel-750 transition-colors"
+          aria-label="Copy policy ID"
+        >
+          <Copy className="w-3.5 h-3.5" />
+        </button>
+        <a
+          href={getPolicyExplorerUrl(policyId)}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={e => e.stopPropagation()}
+          className="p-1 rounded text-dark-100 hover:text-white hover:bg-steel-750 transition-colors"
+          aria-label="View policy on explorer"
+        >
+          <ExternalLink className="w-3.5 h-3.5" />
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export const FTItem = ({ ft, amount, isDisabled, onAmountChange }) => {
+  const decimals = ft.metadata?.decimals ?? 6;
+  const displayName = ft?.ticker || ft?.displayName || ft?.name;
+  const availableDisplay = formatTokenQuantity(ft.quantity, decimals, decimals);
+  const availableExact = formatTokenQuantityExact(ft.quantity, decimals);
+
+  const handleMax = e => {
+    e.stopPropagation();
+    if (isDisabled) return;
+    onAmountChange(ft, getMaxDecimalTokenAmount(ft.quantity, decimals));
+  };
+
+  return (
+    <div className={isDisabled ? 'opacity-50' : ''}>
+      <div className="rounded-md bg-steel-800 px-3 py-2.5 space-y-0">
+        <div className="flex items-center gap-3 min-w-0 mb-2">
           <LazyImage
             src={ft.src}
-            alt={ft?.ticker || ft?.displayName || ft?.name}
+            alt={displayName}
             className="rounded-full shrink-0"
             width={32}
             height={32}
             fallbackSrc="/assets/icons/ada.svg"
           />
-          <div className="flex flex-col flex-1 min-w-0">
-            <span className="font-medium text-sm sm:text-base truncate">
-              {ft?.ticker || ft?.displayName || ft?.name}
-            </span>
-            <span className="text-dark-100 text-xs sm:text-sm whitespace-nowrap">
-              Available: {formatTokenQuantity(ft.quantity, decimals, decimals)}
-            </span>
+          <div className="flex flex-col flex-1 min-w-0 gap-0.5">
+            <span className="font-medium text-sm sm:text-base truncate">{displayName}</span>
+            <div className="flex items-center gap-1 text-xs text-dark-100">
+              <span className="shrink-0">Available:</span>
+              <HoverHelp hint={availableExact} variant="icon" className="inline-flex min-w-0">
+                <span className="tabular-nums truncate border-b border-dotted border-dark-100/50 cursor-help">
+                  {availableDisplay}
+                </span>
+              </HoverHelp>
+            </div>
+          </div>
+          <div className="flex items-stretch gap-1.5 shrink-0">
+            <div className="w-[5.5rem] sm:w-28 flex [&>div]:flex-1 [&>div]:min-w-0">
+              <LavaSteelInput
+                id={`ft-input-${ft.id}`}
+                placeholder="0.00"
+                value={amount}
+                disabled={isDisabled}
+                onChange={value => !isDisabled && onAmountChange(ft, value)}
+              />
+            </div>
+            <button
+              type="button"
+              onClick={handleMax}
+              disabled={isDisabled}
+              className="flex items-center justify-center text-xs font-medium px-2.5 rounded-lg bg-steel-750 hover:bg-steel-700 text-white transition-colors disabled:opacity-50 disabled:cursor-not-allowed shrink-0"
+            >
+              Max
+            </button>
           </div>
         </div>
-        <div className="w-20 sm:w-24 shrink-0">
-          <LavaSteelInput
-            id={`ft-input-${ft.id}`}
-            placeholder="0.00"
-            value={amount}
-            disabled={isDisabled}
-            onChange={value => !isDisabled && onAmountChange(ft, value)}
-          />
-        </div>
-        <a
-          href={
-            IS_PREPROD
-              ? `https://preprod.cardanoscan.io/tokenPolicy/${ft.metadata?.policyId}`
-              : `https://pool.pm/policy/${ft.metadata?.policyId}`
-          }
-          target="_blank"
-          rel="noopener noreferrer"
-          onClick={e => e.stopPropagation()}
-          className="text-dark-100 hover:underline text-sm shrink-0 whitespace-nowrap"
-        >
-          {formatPolicyId(ft.metadata?.policyId)}
-        </a>
+        <PolicyIdRow policyId={ft.metadata?.policyId} />
       </div>
     </div>
   );

--- a/src/utils/core.utils.js
+++ b/src/utils/core.utils.js
@@ -205,6 +205,31 @@ export const formatTokenQuantity = (rawQuantity, decimals = 6, maxDisplayDecimal
   });
 };
 
+/**
+ * Format full token quantity (no compact notation) for tooltips and exact display
+ */
+export const formatTokenQuantityExact = (rawQuantity, decimals = 6) => {
+  const decimalQty = getDecimalAdjustedQuantity(rawQuantity, decimals);
+  const displayDecimals = Math.min(decimals, 8);
+  const multiplier = Math.pow(10, displayDecimals);
+  const truncated = Math.floor(decimalQty * multiplier) / multiplier;
+  return truncated.toLocaleString('en', {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: displayDecimals,
+  });
+};
+
+/**
+ * Max spendable decimal amount string for token inputs (truncated, never rounded up)
+ */
+export const getMaxDecimalTokenAmount = (rawQuantity, decimals = 6) => {
+  const decimalQty = getDecimalAdjustedQuantity(rawQuantity, decimals);
+  const displayDecimals = Math.min(decimals, 8);
+  const multiplier = Math.pow(10, displayDecimals);
+  const truncated = Math.floor(decimalQty * multiplier) / multiplier;
+  return truncated.toFixed(displayDecimals);
+};
+
 export const formatAmount = amount => {
   if (amount >= 1000000) {
     return `${(amount / 1000000).toFixed(1)}M`;


### PR DESCRIPTION
This pull request enhances the user interface and experience for displaying and interacting with fungible tokens in the `AssetsList` modal. The main improvements include replacing the "Policy ID" column with "Amount", redesigning the token item layout, adding a "Max" button for quick input, and improving the display and interaction with policy IDs.

**UI/UX Improvements to Asset List and Token Items:**

* The "Policy ID" column header in `AssetsList.jsx` was replaced with "Amount" to better reflect the content of the column.
* The `FTItem` component was redesigned for improved clarity and usability:
  - The layout now separates available amount display (with tooltip for exact value), token input, and a new "Max" button for quick input of the maximum spendable amount. [[1]](diffhunk://#diff-d0b459a602ea6182beaedc4b74e05504fcc65547f5871cf6913ae41746f0e1e5R1-R95) [[2]](diffhunk://#diff-d0b459a602ea6182beaedc4b74e05504fcc65547f5871cf6913ae41746f0e1e5L40-R114)
  - The policy ID is now displayed in a dedicated row with copy-to-clipboard and explorer link buttons, improving accessibility and user interaction.

**Utility Function Additions:**

* Added `formatTokenQuantityExact` and `getMaxDecimalTokenAmount` utility functions to provide precise formatting and calculation of token amounts for tooltips and "Max" button functionality.

These changes collectively improve the clarity, accessibility, and usability of the asset selection modal for users interacting with fungible tokens.