### PR TITLE
Enhance acquire-only vaults with validation, UI, and tracking features

### DIFF
--- a/src/components/modals/AcquireModal.jsx
+++ b/src/components/modals/AcquireModal.jsx
@@ -3,8 +3,6 @@ import { useWallet } from '@ada-anvil/weld/react';
 import toast from 'react-hot-toast';
 import { ChevronUp, ChevronDown } from 'lucide-react';
 
-import { BUTTON_DISABLE_THRESHOLD_MS } from '../vaults/constants/vaults.constants';
-
 import PrimaryButton from '@/components/shared/PrimaryButton';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 import { formatNum } from '@/utils/core.utils';
@@ -247,11 +245,7 @@ export const AcquireModal = ({ vault, onClose }) => {
               <PrimaryButton
                 className="uppercase"
                 disabled={
-                  status !== 'idle' ||
-                  wallet.isUpdatingUtxos ||
-                  acquireAmountNum < 5 ||
-                  new Date(vault.acquirePhaseStart).getTime() + vault.acquireWindowDuration <
-                    Date.now() + BUTTON_DISABLE_THRESHOLD_MS
+                  status !== 'idle' || wallet.isUpdatingUtxos || acquireAmountNum < 5 || !vault.isAcquireWindowActive
                 }
                 onClick={handleAcquire}
                 icon={status !== 'idle' ? Spinner : null}

--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -8,7 +8,6 @@ import SecondaryButton from '@/components/shared/SecondaryButton.tsx';
 import MetricCard from '@/components/shared/MetricCard.jsx';
 import { useTransaction } from '@/hooks/useTransaction.js';
 import { HoverHelp } from '@/components/shared/HoverHelp.jsx';
-import { BUTTON_DISABLE_THRESHOLD_MS } from '@/components/vaults/constants/vaults.constants.js';
 import { getContributionStatus } from '@/utils/vaultContributionLimits.js';
 import { useVaultAssets } from '@/services/api/queries.js';
 import { useInfiniteWalletAssets } from '@/hooks/useInfiniteWalletAssets.ts';
@@ -315,12 +314,7 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
                 selectedNFTs.length === 0 ||
                 status !== 'idle' ||
                 wallet.isUpdatingUtxos ||
-                (isExpansionMode
-                  ? vault.expansionPhaseStart &&
-                    new Date(vault.expansionPhaseStart).getTime() + vault.expansionDuration <
-                      Date.now() + BUTTON_DISABLE_THRESHOLD_MS
-                  : new Date(vault.contributionPhaseStart).getTime() + vault.contributionDuration <
-                    Date.now() + BUTTON_DISABLE_THRESHOLD_MS)
+                !vault.isContributionWindowActive
               }
               onClick={handleContribute}
               size="sm"

--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -167,12 +167,15 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
 
   const estimatedTickerVal = hasSelectedAssets ? userEstimatedTokens.toLocaleString() : '0';
 
-  // Estimated Amount to Receive = (1 - Tokens for Acquirers % - LP ADA %) × Estimated Value
-  // LP ADA % = LP Contribution % / 2 (since LP gets half as VT, half as ADA)
-  // This represents the portion of contributed value returned to contributors as ADA
-  const estimatedReceived = hasSelectedAssets
-    ? ((1 - tokensForAcqPercent - lpContributionPercent / 2) * estimatedValue).toFixed(2).toLocaleString()
-    : '0.00';
+  // Estimated ADA to Receive (only shown when acquire phase exists)
+  // Contributors receive ADA from acquirers (minus LP allocation)
+  // Formula: Estimated Value × (Tokens for Acquirers % - LP ADA %)
+  // Where LP ADA % = LP Contribution % / 2
+  const hasAcquirePhase = tokensForAcqPercent > 0;
+  const estimatedReceived =
+    hasSelectedAssets && hasAcquirePhase
+      ? ((tokensForAcqPercent - lpContributionPercent / 2) * estimatedValue).toFixed(2).toLocaleString()
+      : '0.00';
   const estimatedReceivedLabel = isAda ? 'Estimated ADA Received' : 'Estimated USD Received';
 
   const toggleNFT = useCallback(asset => {
@@ -439,7 +442,7 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
               />
             )}
 
-            {!isExpansionMode && (
+            {!isExpansionMode && hasAcquirePhase && (
               <MetricCard
                 label={estimatedReceivedLabel}
                 value={`${currencySymbol}${estimatedReceived}`}

--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -28,12 +28,16 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
     const MAX_ADA_LIMIT = 1000000000; // 1 billion ADA
     const MAX_LIMIT_PRICE = 1000000; // 1 million VT per 1 ADA
 
+    // Calculate minimum limit price based on vault decimals to prevent multiplier = 0
+    const decimals = vault?.ft_token_decimals || 6;
+    const minLimitPrice = Math.pow(10, -decimals);
+
     const isValid =
       (noLimit || duration > 0) &&
       (noMax || (maxAda && maxAdaNum > 0 && maxAdaNum <= MAX_ADA_LIMIT)) &&
       hasAtLeastOneLimit &&
       priceType &&
-      (priceType === 'market' || (limitPrice && limitPriceNum > 0 && limitPriceNum <= MAX_LIMIT_PRICE));
+      (priceType === 'market' || (limitPrice && limitPriceNum >= minLimitPrice && limitPriceNum <= MAX_LIMIT_PRICE));
 
     // Convert ADA to lovelace for backend (1 ADA = 1,000,000 lovelace)
     const maxAdaLovelace = noMax ? null : Math.floor(Math.min(maxAdaNum, MAX_ADA_LIMIT) * 1000000) || null;
@@ -47,7 +51,7 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
       acquireExpansionLimitPrice: priceType === 'limit' ? Math.min(limitPriceNum, MAX_LIMIT_PRICE) : null,
       isValid,
     });
-  }, [duration, noLimit, maxAda, noMax, priceType, limitPrice, onDataChange]);
+  }, [duration, noLimit, maxAda, noMax, priceType, limitPrice, onDataChange, vault?.ft_token_decimals]);
 
   return (
     <div className="space-y-6">
@@ -176,14 +180,39 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
                 error={error && !limitPrice}
               />
               {error && !limitPrice && <p className="text-red-500 text-sm mt-1">Limit price is required</p>}
-              {limitPrice && parseFloat(limitPrice) > 0 && (
-                <div className="mt-2 p-3 bg-steel-800 rounded">
-                  <p className="text-xs text-gray-400">Example calculation:</p>
-                  <p className="text-sm text-primary font-mono mt-1">
-                    100 ₳ = {(parseFloat(limitPrice) * 100).toLocaleString()} VT
-                  </p>
-                </div>
-              )}
+              {(() => {
+                const decimals = vault?.ft_token_decimals || 6;
+                const minLimitPrice = Math.pow(10, -decimals);
+                const limitPriceNum = parseFloat(limitPrice) || 0;
+
+                if (limitPrice && limitPriceNum > 0 && limitPriceNum < minLimitPrice) {
+                  return (
+                    <div className="mt-2 p-3 bg-red-900/20 border border-red-600/50 rounded">
+                      <p className="text-red-400 text-sm font-medium">⚠️ Price Too Low</p>
+                      <p className="text-red-300/90 text-xs mt-1">
+                        With {decimals} decimals, minimum limit price is {minLimitPrice} VT per 1 ADA. Lower values
+                        would result in 0 tokens minted.
+                      </p>
+                    </div>
+                  );
+                }
+
+                if (limitPrice && limitPriceNum > 0) {
+                  return (
+                    <div className="mt-2 p-3 bg-steel-800 rounded">
+                      <p className="text-xs text-gray-400">Example calculation:</p>
+                      <p className="text-sm text-primary font-mono mt-1">
+                        100 ₳ = {(limitPriceNum * 100).toLocaleString()} VT
+                      </p>
+                      <p className="text-xs text-gray-500 mt-1">
+                        Min: {minLimitPrice} VT/ADA ({decimals} decimals)
+                      </p>
+                    </div>
+                  );
+                }
+
+                return null;
+              })()}
             </div>
           )}
 

--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -1,0 +1,258 @@
+import { useEffect, useState } from 'react';
+
+import { LavaSteelSelect } from '@/components/shared/LavaSelect';
+import { LavaIntervalPicker } from '@/components/shared/LavaIntervalPicker';
+import { LavaSteelInput } from '@/components/shared/LavaInput';
+import { LavaCheckbox } from '@/components/shared/LavaCheckbox';
+import { HoverHelp } from '@/components/shared/HoverHelp';
+
+export default function AcquireExpansion({ onDataChange, error, vault }) {
+  const [duration, setDuration] = useState(null);
+  const [noLimit, setNoLimit] = useState(false);
+  const [maxAda, setMaxAda] = useState('');
+  const [noMax, setNoMax] = useState(false);
+  const [priceType, setPriceType] = useState('market');
+  const [limitPrice, setLimitPrice] = useState('');
+
+  const priceTypeOptions = [
+    { value: 'market', label: 'Market Price' },
+    { value: 'limit', label: 'Limit Price' },
+  ];
+
+  useEffect(() => {
+    // Cannot have both noLimit and noMax true - at least one limit must be set
+    const hasAtLeastOneLimit = !(noLimit && noMax);
+
+    const maxAdaNum = parseFloat(maxAda) || 0;
+    const limitPriceNum = parseFloat(limitPrice) || 0;
+    const MAX_ADA_LIMIT = 1000000000; // 1 billion ADA
+    const MAX_LIMIT_PRICE = 1000000; // 1 million VT per 1 ADA
+
+    const isValid =
+      (noLimit || duration > 0) &&
+      (noMax || (maxAda && maxAdaNum > 0 && maxAdaNum <= MAX_ADA_LIMIT)) &&
+      hasAtLeastOneLimit &&
+      priceType &&
+      (priceType === 'market' || (limitPrice && limitPriceNum > 0 && limitPriceNum <= MAX_LIMIT_PRICE));
+
+    // Convert ADA to lovelace for backend (1 ADA = 1,000,000 lovelace)
+    const maxAdaLovelace = noMax ? null : Math.floor(Math.min(maxAdaNum, MAX_ADA_LIMIT) * 1000000) || null;
+
+    onDataChange?.({
+      acquireExpansionDuration: noLimit ? null : duration,
+      acquireExpansionNoLimit: noLimit,
+      acquireExpansionMaxAda: maxAdaLovelace,
+      acquireExpansionNoMax: noMax,
+      acquireExpansionPriceType: priceType,
+      acquireExpansionLimitPrice: priceType === 'limit' ? Math.min(limitPriceNum, MAX_LIMIT_PRICE) : null,
+      isValid,
+    });
+  }, [duration, noLimit, maxAda, noMax, priceType, limitPrice, onDataChange]);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-6">
+        <h3 className="text-lg font-medium text-white">Acquire Expansion Configuration</h3>
+
+        <div className="p-4 bg-steel-700 rounded-lg">
+          <p className="text-sm text-gray-300">
+            <strong>Acquire Expansion</strong> allows the vault to reopen for new ADA contributions in exchange for
+            newly minted vault tokens. Users send ADA and receive VT based on the pricing model selected below.
+          </p>
+        </div>
+
+        {/* Duration */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
+              Expansion Duration*
+              <HoverHelp hint="How long the vault will accept new ADA contributions" />
+            </label>
+            <LavaCheckbox
+              name="acquireExpansionNoLimit"
+              checked={noLimit}
+              onChange={e => setNoLimit(e.target.checked)}
+              description="No Limit"
+              disabled={noMax}
+            />
+          </div>
+          {!noLimit ? (
+            <>
+              <LavaIntervalPicker
+                variant={'steel'}
+                value={duration}
+                onChange={setDuration}
+                placeholder="DD:HH:MM"
+                error={error && !duration}
+              />
+            </>
+          ) : (
+            <div className="p-3 bg-steel-700 rounded-lg">
+              <p className="text-sm text-gray-300">
+                Vault will remain open until closed by governance action or max ADA is reached
+              </p>
+            </div>
+          )}
+          {noLimit && noMax && (
+            <p className="text-red-500 text-sm mt-2">At least one limit (Duration or Maximum ADA) must be set</p>
+          )}
+        </div>
+
+        {/* Max ADA */}
+        <div>
+          <div className="flex items-center justify-between mb-2">
+            <label className="flex items-center gap-1.5 text-sm font-medium text-gray-300">
+              Maximum ADA*
+              <HoverHelp hint="Total ADA that can be raised during this expansion window (max: 1 billion ADA)" />
+            </label>
+            <LavaCheckbox
+              name="acquireExpansionNoMax"
+              checked={noMax}
+              onChange={e => setNoMax(e.target.checked)}
+              description="No Max"
+              disabled={noLimit}
+            />
+          </div>
+          {!noMax ? (
+            <>
+              <LavaSteelInput
+                type="number"
+                min="1"
+                max="1000000000"
+                step="1"
+                value={maxAda}
+                onChange={value => {
+                  const numValue = parseFloat(value);
+                  if (numValue > 1000000000) {
+                    setMaxAda('1000000000');
+                  } else {
+                    setMaxAda(value);
+                  }
+                }}
+                placeholder="Enter maximum ADA (e.g., 10000)"
+                error={error && !maxAda}
+              />
+              {maxAda && parseFloat(maxAda) > 1000000 && (
+                <p className="text-xs text-yellow-400 mt-1">
+                  Large limit set ({parseFloat(maxAda).toLocaleString()} ADA). Consider if this is intentional.
+                </p>
+              )}
+            </>
+          ) : (
+            <div className="p-3 bg-steel-700 rounded-lg">
+              <p className="text-sm text-gray-300">
+                Unlimited ADA can be accepted until duration ends or governance closes the vault
+              </p>
+            </div>
+          )}
+        </div>
+
+        {/* Price Type */}
+        <div>
+          <label className="block text-sm font-medium text-gray-300 mb-2">VT Price per ADA*</label>
+          <LavaSteelSelect options={priceTypeOptions} value={priceType} onChange={setPriceType} />
+
+          {priceType === 'limit' && (
+            <div className="mt-3">
+              <label className="flex items-center gap-1.5 text-sm font-medium text-gray-300 mb-2">
+                Limit Price (VT per 1 ADA)
+                <HoverHelp hint="Fixed amount of vault tokens contributors will receive per 1 ADA (max: 1,000,000 VT)" />
+              </label>
+              <LavaSteelInput
+                type="number"
+                step="0.000001"
+                min="0"
+                max="1000000"
+                value={limitPrice}
+                onChange={value => {
+                  const numValue = parseFloat(value);
+                  if (numValue > 1000000) {
+                    setLimitPrice('1000000');
+                  } else {
+                    setLimitPrice(value);
+                  }
+                }}
+                placeholder="Enter VT per 1 ADA (up to 6 decimals, max 1M)"
+                error={error && !limitPrice}
+              />
+              {error && !limitPrice && <p className="text-red-500 text-sm mt-1">Limit price is required</p>}
+              {limitPrice && parseFloat(limitPrice) > 0 && (
+                <div className="mt-2 p-3 bg-steel-800 rounded">
+                  <p className="text-xs text-gray-400">Example calculation:</p>
+                  <p className="text-sm text-primary font-mono mt-1">
+                    100 ₳ = {(parseFloat(limitPrice) * 100).toLocaleString()} VT
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+
+          {priceType === 'market' && (
+            <div className="mt-3 space-y-2">
+              <div className="p-4 bg-steel-700 rounded-lg space-y-2">
+                <p className="text-sm text-gray-300">
+                  <strong>Market Price Calculation:</strong>
+                </p>
+                <p className="text-sm text-gray-300">
+                  Contributors will receive VT based on the current market price from the Liquidity Pool:
+                </p>
+                <div className="p-3 bg-steel-800 rounded font-mono text-sm text-primary">
+                  VT Amount = ADA Sent × (Current VT/ADA Price from LP)
+                </div>
+                <p className="text-xs text-gray-400">
+                  This ensures contributors receive VT at fair market value based on DEX prices (DexHunter, Taptools)
+                </p>
+              </div>
+              {!vault?.hasActiveLp && (
+                <div className="p-3 bg-yellow-900/20 border border-yellow-600/50 rounded-lg">
+                  <p className="text-yellow-400 text-sm font-medium">⚠️ Market Pricing Requirements:</p>
+                  <p className="text-yellow-300/90 text-xs mt-1">
+                    This vault does not have an active Liquidity Pool on DEXes. Market pricing requires an active LP
+                    with at least 1,000 ADA in liquidity. Please use <strong>Limit Price</strong> instead, or create an
+                    LP first.
+                  </p>
+                </div>
+              )}
+              {vault?.hasActiveLp && vault?.vtPrice && (
+                <div className="p-3 bg-primary/10 border border-primary/30 rounded-lg">
+                  <p className="text-primary text-sm font-medium">✓ LP Detected</p>
+                  <p className="text-gray-300 text-xs mt-1">Current VT Price: {vault.vtPrice.toFixed(6)} ₳ per VT</p>
+                  <p className="text-gray-400 text-xs mt-1">
+                    Example: 100 ₳ = ~{(100 / vault.vtPrice).toFixed(2)} VT (at current price)
+                  </p>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+
+        {/* Summary Box */}
+        {/* <div className="p-4 bg-primary/10 border border-primary/30 rounded-lg">
+          <h4 className="text-sm font-semibold text-primary mb-2">Expansion Summary</h4>
+          <div className="space-y-1 text-sm text-gray-300">
+            <p>
+              <span className="text-gray-400">Duration:</span>{' '}
+              {noLimit
+                ? 'No limit'
+                : duration
+                  ? `${Math.floor(duration / 86400000)}d ${Math.floor((duration % 86400000) / 3600000)}h ${Math.floor((duration % 3600000) / 60000)}m`
+                  : 'Not set'}
+            </p>
+            <p>
+              <span className="text-gray-400">Max ADA:</span>{' '}
+              {noMax ? 'Unlimited' : maxAda ? `${parseFloat(maxAda).toLocaleString()} ₳` : 'Not set'}
+            </p>
+            <p>
+              <span className="text-gray-400">Pricing:</span>{' '}
+              {priceType === 'market'
+                ? 'Market price (from LP)'
+                : limitPrice
+                  ? `${limitPrice} VT per 1 ₳`
+                  : 'Not set'}
+            </p>
+          </div>
+        </div> */}
+      </div>
+    </div>
+  );
+}

--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -29,7 +29,7 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
     const MAX_LIMIT_PRICE = 1000000; // 1 million VT per 1 ADA
 
     // Calculate minimum limit price based on vault decimals to prevent multiplier = 0
-    const decimals = vault?.ft_token_decimals || 6;
+    const decimals = vault?.ftTokenDecimals || 6;
     const minLimitPrice = Math.pow(10, -decimals);
 
     const isValid =
@@ -181,7 +181,7 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
               />
               {error && !limitPrice && <p className="text-red-500 text-sm mt-1">Limit price is required</p>}
               {(() => {
-                const decimals = vault?.ft_token_decimals || 6;
+                const decimals = vault?.ftTokenDecimals || 6;
                 const minLimitPrice = Math.pow(10, -decimals);
                 const limitPriceNum = parseFloat(limitPrice) || 0;
 

--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -204,9 +204,7 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
                       <p className="text-sm text-primary font-mono mt-1">
                         100 ₳ = {(limitPriceNum * 100).toLocaleString()} VT
                       </p>
-                      <p className="text-xs text-gray-500 mt-1">
-                        Min: {minLimitPrice} VT/ADA ({decimals} decimals)
-                      </p>
+                      <p className="text-xs text-gray-500 mt-1">Min: {minLimitPrice} VT/ADA</p>
                     </div>
                   );
                 }

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -35,7 +35,7 @@ const executionOptions = [
   { value: 'marketplace_action', label: 'Market Actions' },
   { value: 'expansion', label: 'Vault Expansion' },
   { value: 'acquire_expansion', label: 'Acquire Expansion' },
-  { value: 'distribution', label: 'Distribution - Coming Soon', disabled: false },
+  { value: 'distribution', label: 'Distribution - Coming Soon', disabled: true },
   { value: 'staking', label: 'Staking - Coming Soon', disabled: true },
   { value: 'termination', label: 'Termination - Coming Soon', disabled: true },
   { value: 'burning', label: 'Burning - Coming Soon', disabled: true },
@@ -49,7 +49,9 @@ const initialProposalData = {
 export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   const [proposalTitle, setProposalTitle] = useState('');
   const [proposalDescription, setProposalDescription] = useState('');
-  const [selectedOption, setSelectedOption] = useState('acquire_expansion');
+  const [selectedOption, setSelectedOption] = useState(
+    vault.vaultStatus === VAULT_STATUSES.EXPANSION ? 'distribution' : 'marketplace_action'
+  );
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [proposalData, setProposalData] = useState(initialProposalData);
   const [proposalStartDate, setProposalStartDate] = useState(null);

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -81,9 +81,10 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   }, [governanceFees, selectedOption]);
 
   // Filter execution options based on vault status
-  // During expansion, only Distribution is allowed (doesn't extract from vault)
+  // During expansion or acquire_expansion, only Distribution is allowed (doesn't extract from vault)
   const availableExecutionOptions = useMemo(() => {
-    const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
+    const isExpansion =
+      vault.vaultStatus === VAULT_STATUSES.EXPANSION || vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION;
 
     if (isExpansion) {
       return executionOptions.map(option => {

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -14,6 +14,7 @@ import SecondaryButton from '@/components/shared/SecondaryButton';
 import Terminating from '@/components/modals/CreateProposalModal/Terminating.jsx';
 import Burning from '@/components/modals/CreateProposalModal/Burning.jsx';
 import Expansion from '@/components/modals/CreateProposalModal/Expansion.jsx';
+import AcquireExpansion from '@/components/modals/CreateProposalModal/AcquireExpansion.jsx';
 import {
   useCreateProposal,
   useGovernanceProposals,
@@ -33,6 +34,7 @@ import { MarketActions } from '@/components/modals/CreateProposalModal/MarketAct
 const executionOptions = [
   { value: 'marketplace_action', label: 'Market Actions' },
   { value: 'expansion', label: 'Vault Expansion' },
+  { value: 'acquire_expansion', label: 'Acquire Expansion' },
   { value: 'distribution', label: 'Distribution - Coming Soon', disabled: true },
   { value: 'staking', label: 'Staking - Coming Soon', disabled: true },
   { value: 'termination', label: 'Termination - Coming Soon', disabled: true },
@@ -47,9 +49,7 @@ const initialProposalData = {
 export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   const [proposalTitle, setProposalTitle] = useState('');
   const [proposalDescription, setProposalDescription] = useState('');
-  const [selectedOption, setSelectedOption] = useState(
-    vault.vaultStatus === VAULT_STATUSES.EXPANSION ? 'distribution' : 'marketplace_action'
-  );
+  const [selectedOption, setSelectedOption] = useState('acquire_expansion');
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [proposalData, setProposalData] = useState(initialProposalData);
   const [proposalStartDate, setProposalStartDate] = useState(null);
@@ -72,6 +72,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       marketplace_action: governanceFees.data.proposalFeeMarketplaceAction,
       distribution: governanceFees.data.proposalFeeDistribution,
       expansion: governanceFees.data.proposalFeeExpansion,
+      acquire_expansion: governanceFees.data.proposalFeeExpansion, // Use same fee as expansion
       staking: governanceFees.data.proposalFeeStaking,
       termination: governanceFees.data.proposalFeeTermination,
       burning: governanceFees.data.proposalFeeBurning,
@@ -166,6 +167,13 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
         proposalPayload.expansionNoMax = proposalData.expansionNoMax || false;
         proposalPayload.expansionPriceType = proposalData.expansionPriceType || 'market';
         proposalPayload.expansionLimitPrice = proposalData.expansionLimitPrice;
+      } else if (selectedOption === 'acquire_expansion') {
+        proposalPayload.acquireExpansionDuration = proposalData.acquireExpansionDuration;
+        proposalPayload.acquireExpansionNoLimit = proposalData.acquireExpansionNoLimit || false;
+        proposalPayload.acquireExpansionMaxAda = proposalData.acquireExpansionMaxAda;
+        proposalPayload.acquireExpansionNoMax = proposalData.acquireExpansionNoMax || false;
+        proposalPayload.acquireExpansionPriceType = proposalData.acquireExpansionPriceType || 'market';
+        proposalPayload.acquireExpansionLimitPrice = proposalData.acquireExpansionLimitPrice;
       } else if (selectedOption === 'termination') {
         proposalPayload.metadata = {
           proposalStart: proposalData.proposalStart || null,
@@ -450,6 +458,9 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
             )}
             {selectedOption === 'expansion' && (
               <Expansion vault={vault} onDataChange={handleDataChange} error={error} />
+            )}
+            {selectedOption === 'acquire_expansion' && (
+              <AcquireExpansion vault={vault} onDataChange={handleDataChange} error={error} />
             )}
 
             <div className="mt-8">

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -35,7 +35,7 @@ const executionOptions = [
   { value: 'marketplace_action', label: 'Market Actions' },
   { value: 'expansion', label: 'Vault Expansion' },
   { value: 'acquire_expansion', label: 'Acquire Expansion' },
-  { value: 'distribution', label: 'Distribution - Coming Soon', disabled: true },
+  { value: 'distribution', label: 'Distribution - Coming Soon', disabled: false },
   { value: 'staking', label: 'Staking - Coming Soon', disabled: true },
   { value: 'termination', label: 'Termination - Coming Soon', disabled: true },
   { value: 'burning', label: 'Burning - Coming Soon', disabled: true },

--- a/src/components/shared/LavaRadio.jsx
+++ b/src/components/shared/LavaRadio.jsx
@@ -13,6 +13,8 @@ const presetHelpfulHint = {
   acquirers_50:
     'Simple vault where Contributors send assets to receive 50% pro-rata of Vault Token MINUS LP contribution AND pro-rata of ADA sent by acquirers MINUS ADA LP contribution. Acquirers send ADA to receive 50% of pro-rata vault token MINUS Vault Token LP contribution.',
   advanced: 'Customizable vault based on user settings for all fields.',
+  acquire_only:
+    'Acquire-Only vault with no Contribution phase. Acquirers send ADA directly to receive pro-rata Vault Tokens (100%). ADA goes straight to the vault treasury. Vault locks once the acquire window closes and the minimum ADA threshold is met.',
 };
 
 export const LavaRadio = ({

--- a/src/components/vault-profile/ProposalInfo.jsx
+++ b/src/components/vault-profile/ProposalInfo.jsx
@@ -387,8 +387,8 @@ export const ProposalInfo = ({ proposalId }) => {
               value: 'No limit',
             });
           } else if (acquireExpansionConfig.maxAda) {
-            const maxAdaAmount = acquireExpansionConfig.maxAda / 1_000_000; // Convert lovelace to ADA
-            const currentAdaRaised = (acquireExpansionConfig.currentAdaRaised || 0) / 1_000_000;
+            const maxAdaAmount = acquireExpansionConfig.maxAda / 1000000; // Convert lovelace to ADA
+            const currentAdaRaised = (acquireExpansionConfig.currentAdaRaised || 0) / 1000000;
             const progressPercent = (currentAdaRaised / maxAdaAmount) * 100;
             acquireExpansionItems.push({
               label: 'ADA Limit',

--- a/src/components/vault-profile/ProposalInfo.jsx
+++ b/src/components/vault-profile/ProposalInfo.jsx
@@ -360,6 +360,62 @@ export const ProposalInfo = ({ proposalId }) => {
         return expansionItems;
       }
 
+      case 'acquire_expansion': {
+        const acquireExpansionItems = [executionOptions];
+        const acquireExpansionConfig = proposalInfo?.metadata?.acquireExpansion;
+
+        if (acquireExpansionConfig) {
+          // Duration
+          if (acquireExpansionConfig.noLimit) {
+            acquireExpansionItems.push({
+              label: 'Duration',
+              value: 'No time limit',
+            });
+          } else if (acquireExpansionConfig.duration) {
+            const days = Math.floor(acquireExpansionConfig.duration / (24 * 60 * 60 * 1000));
+            const hours = Math.floor((acquireExpansionConfig.duration % (24 * 60 * 60 * 1000)) / (60 * 60 * 1000));
+            acquireExpansionItems.push({
+              label: 'Duration',
+              value: days > 0 ? `${days} day${days > 1 ? 's' : ''}` : `${hours} hour${hours > 1 ? 's' : ''}`,
+            });
+          }
+
+          // Max ADA / Progress
+          if (acquireExpansionConfig.noMax) {
+            acquireExpansionItems.push({
+              label: 'ADA Limit',
+              value: 'No limit',
+            });
+          } else if (acquireExpansionConfig.maxAda) {
+            const maxAdaAmount = acquireExpansionConfig.maxAda / 1_000_000; // Convert lovelace to ADA
+            const currentAdaRaised = (acquireExpansionConfig.currentAdaRaised || 0) / 1_000_000;
+            const progressPercent = (currentAdaRaised / maxAdaAmount) * 100;
+            acquireExpansionItems.push({
+              label: 'ADA Limit',
+              value: `${currentAdaRaised.toLocaleString()} / ${maxAdaAmount.toLocaleString()} ₳ (${progressPercent.toFixed(1)}%)`,
+            });
+          }
+
+          // Pricing Method
+          if (acquireExpansionConfig.priceType === 'limit' && acquireExpansionConfig.limitPrice) {
+            acquireExpansionItems.push({
+              label: 'Pricing Method',
+              value: `Fixed: ${acquireExpansionConfig.limitPrice} VT per 1 ₳`,
+            });
+          } else if (acquireExpansionConfig.priceType === 'market') {
+            const marketPriceDisplay = acquireExpansionConfig.marketPriceSnapshot
+              ? ` (${acquireExpansionConfig.marketPriceSnapshot.toFixed(6)} VT/₳ at proposal creation)`
+              : '';
+            acquireExpansionItems.push({
+              label: 'Pricing Method',
+              value: `Market (current LP price)${marketPriceDisplay}`,
+            });
+          }
+        }
+
+        return acquireExpansionItems;
+      }
+
       default:
         return [];
     }

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -172,12 +172,16 @@ export const VaultContribution = ({ vault }) => {
   const isAcquire = vault.vaultStatus === VAULT_STATUSES.ACQUIRE;
   const isLocked = vault.vaultStatus === VAULT_STATUSES.LOCKED;
   const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
+  const isAcquireOnly = vault.isAcquireOnly;
 
   const contributionProgress = calculateProgress(vault.assetsCount, vault.maxContributeAssets);
   const acquireProgress = calculateAcquireProgress(vault.assetsPrices.totalAcquiredUsd, vault.requireReservedCostUsd);
   const minContributeAssets = findMinValue(vault.assetsWhitelist, 'countCapMin');
 
   const reserveThresholdMet = acquireProgress >= 100;
+
+  // For acquire-only vaults, only show progress bar if reserve threshold exists
+  const hasReserveThreshold = vault.requireReservedCostAda > 0 || vault.requireReservedCostUsd > 0;
 
   const lpMinThresholdPosition = calculateLpMinThresholdPosition(
     vault.lpMinLiquidityAda,
@@ -190,7 +194,7 @@ export const VaultContribution = ({ vault }) => {
   return (
     <div className="space-y-4">
       <div className="relative overflow-visible">
-        {isContribution && (
+        {isContribution && !isAcquireOnly && (
           <ContributionProgress
             title="Contribution"
             contributionProgress={contributionProgress}
@@ -206,77 +210,85 @@ export const VaultContribution = ({ vault }) => {
       </div>
 
       <div className="relative">
-        {isContribution ? null : isAcquire ? (
-          <div>
-            <h2 className="font-medium mb-2">Acquire:</h2>
-            <div className="flex justify-between text-sm mb-1">
-              <span className="text-dark-100">
-                Reserve:{' '}
-                {currency === 'ada'
-                  ? `₳${formatNum(vault.requireReservedCostAda)}`
-                  : `$${formatNum(vault.requireReservedCostUsd)}`}
-              </span>
-              <span className="text-dark-100">{Math.floor(acquireProgress)}%</span>
-            </div>
-            <div className="relative">
-              <LavaProgressBar
-                className="h-2 rounded-full bg-steel-750 mb-4"
-                segments={[
-                  {
-                    progress: Math.min(acquireProgress, 100),
-                    className: 'bg-gradient-to-r from-[#F9731600] to-[#F97316]',
-                  },
-                  ...(reserveThresholdMet
-                    ? [
-                        {
-                          progress: acquireProgress - 100,
-                          className: 'bg-gradient-to-r from-[#FB2C3600] to-[#FB2C36]',
-                        },
-                      ]
-                    : []),
-                ]}
-              />
-            </div>
-            {vault.liquidityPoolContribution > 0 && (
-              <div className="flex flex-col gap-1 text-xs mt-2">
-                {!canMeetLpMinimum ? (
-                  <div className="flex flex-col gap-1 p-2 border border-red-500/30 bg-red-500/5 rounded mt-1">
-                    <span className="text-red-400 font-medium">Vault will FAIL at lock</span>
-                    <span className="text-red-300 text-xs">
-                      LP is required but estimated ADA portion of LP (₳{formatNum(vault.projectedLpAdaAmount)}) is below
-                      minimum (₳{vault.lpMinLiquidityAda}). Vault needs more acquire contributions or will fail and
-                      refund users.
-                    </span>
-                  </div>
-                ) : (
-                  <>
-                    <div className="flex justify-between">
-                      <span className="text-dark-100">Current ADA LP amount:</span>
-                      <span className="text-dark-100">
-                        {currency === 'ada'
-                          ? `₳${formatNum(vault.projectedLpAdaAmount)}`
-                          : `$${formatNum(vault.projectedLpUsdAmount)}`}
+        {isContribution && !isAcquireOnly ? null : isAcquire ? (
+          hasReserveThreshold ? (
+            <div>
+              <h2 className="font-medium mb-2">Acquire:</h2>
+              <div className="flex justify-between text-sm mb-1">
+                <span className="text-dark-100">
+                  Reserve:{' '}
+                  {currency === 'ada'
+                    ? `₳${formatNum(vault.requireReservedCostAda)}`
+                    : `$${formatNum(vault.requireReservedCostUsd)}`}
+                </span>
+                <span className="text-dark-100">{Math.floor(acquireProgress)}%</span>
+              </div>
+              <div className="relative">
+                <LavaProgressBar
+                  className="h-2 rounded-full bg-steel-750 mb-4"
+                  segments={[
+                    {
+                      progress: Math.min(acquireProgress, 100),
+                      className: 'bg-gradient-to-r from-[#F9731600] to-[#F97316]',
+                    },
+                    ...(reserveThresholdMet
+                      ? [
+                          {
+                            progress: acquireProgress - 100,
+                            className: 'bg-gradient-to-r from-[#FB2C3600] to-[#FB2C36]',
+                          },
+                        ]
+                      : []),
+                  ]}
+                />
+              </div>
+              {vault.liquidityPoolContribution > 0 && (
+                <div className="flex flex-col gap-1 text-xs mt-2">
+                  {!canMeetLpMinimum ? (
+                    <div className="flex flex-col gap-1 p-2 border border-red-500/30 bg-red-500/5 rounded mt-1">
+                      <span className="text-red-400 font-medium">Vault will FAIL at lock</span>
+                      <span className="text-red-300 text-xs">
+                        LP is required but estimated ADA portion of LP (₳{formatNum(vault.projectedLpAdaAmount)}) is
+                        below minimum (₳{vault.lpMinLiquidityAda}). Vault needs more acquire contributions or will fail
+                        and refund users.
                       </span>
                     </div>
-                    <div className="flex justify-between">
-                      <span className="text-dark-100">LP Minimum (₳{vault.lpMinLiquidityAda}):</span>
-                      <span className={lpMinThresholdMet ? 'text-green-400' : 'text-yellow-400'}>
-                        {lpMinThresholdMet ? '✓ LP Threshold met' : 'Not yet reached'}
-                      </span>
-                    </div>
-                    {!lpMinThresholdMet && (
-                      <div className="flex flex-col gap-1 p-2 border border-yellow-500/30 bg-yellow-500/5 rounded mt-1">
-                        <span className="text-yellow-300 text-xs">
-                          LP minimum not yet met. Vault will fail to lock if acquire contributions don't reach{' '}
-                          {Math.ceil(lpMinThresholdPosition)}% reserve threshold.
+                  ) : (
+                    <>
+                      <div className="flex justify-between">
+                        <span className="text-dark-100">Current ADA LP amount:</span>
+                        <span className="text-dark-100">
+                          {currency === 'ada'
+                            ? `₳${formatNum(vault.projectedLpAdaAmount)}`
+                            : `$${formatNum(vault.projectedLpUsdAmount)}`}
                         </span>
                       </div>
-                    )}
-                  </>
-                )}
-              </div>
-            )}
-          </div>
+                      <div className="flex justify-between">
+                        <span className="text-dark-100">LP Minimum (₳{vault.lpMinLiquidityAda}):</span>
+                        <span className={lpMinThresholdMet ? 'text-green-400' : 'text-yellow-400'}>
+                          {lpMinThresholdMet ? '✓ LP Threshold met' : 'Not yet reached'}
+                        </span>
+                      </div>
+                      {!lpMinThresholdMet && (
+                        <div className="flex flex-col gap-1 p-2 border border-yellow-500/30 bg-yellow-500/5 rounded mt-1">
+                          <span className="text-yellow-300 text-xs">
+                            LP minimum not yet met. Vault will fail to lock if acquire contributions don't reach{' '}
+                            {Math.ceil(lpMinThresholdPosition)}% reserve threshold.
+                          </span>
+                        </div>
+                      )}
+                    </>
+                  )}
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="text-sm text-dark-100">
+              {isAcquireOnly
+                ? 'Acquire-only vault - no minimum threshold required'
+                : 'Acquire phase active - contributions accepted until phase expires'}
+            </div>
+          )
         ) : isLocked && vault.assetsPrices.totalAcquiredAda && vault.assetsPrices.totalAcquiredUsd ? (
           <div className="w-full">
             <div className="text-sm text-dark-100 font-medium">

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -172,6 +172,7 @@ export const VaultContribution = ({ vault }) => {
   const isAcquire = vault.vaultStatus === VAULT_STATUSES.ACQUIRE;
   const isLocked = vault.vaultStatus === VAULT_STATUSES.LOCKED;
   const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
+  const isAcquireExpansion = vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION;
   const isAcquireOnly = vault.isAcquireOnly;
 
   const contributionProgress = calculateProgress(vault.assetsCount, vault.maxContributeAssets);

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -317,6 +317,24 @@ export const VaultContribution = ({ vault }) => {
             showMoreInfo={showMoreInfo}
             setShowMoreInfo={setShowMoreInfo}
           />
+        ) : isAcquireExpansion ? (
+          <>
+            <ContributionProgress
+              title="Expansion"
+              contributionProgress={
+                vault.expansionAssetMax > 0
+                  ? calculateProgress(vault.expansionAssetsCount || 0, vault.expansionAssetMax)
+                  : 0
+              }
+              minContributeAssets={0}
+              maxContributeAssets={vault.expansionAssetMax}
+              assetList={vault.expansionAssetsByPolicy || []}
+              assetsCount={vault.expansionAssetsCount || 0}
+              assetsByPolicy={vault.expansionAssetsByPolicy || []}
+              showMoreInfo={showMoreInfo}
+              setShowMoreInfo={setShowMoreInfo}
+            />
+          </>
         ) : null}
       </div>
 

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -337,10 +337,61 @@ export const VaultContribution = ({ vault }) => {
               )}
             </div>
           ) : (
-            <div className="text-sm text-dark-100">
-              {isAcquireOnly
-                ? 'Acquire-only vault - no minimum threshold required'
-                : 'Acquire phase active - contributions accepted until phase expires'}
+            <div>
+              {isAcquireOnly ? (
+                <>
+                  {vault.liquidityPoolContribution === 0 && (
+                    <div className="text-sm text-dark-100 mb-3">Acquire-only vault - no minimum threshold required</div>
+                  )}
+                  {vault.liquidityPoolContribution > 0 && (
+                    <div className="flex flex-col gap-1 text-xs">
+                      {!canMeetLpMinimum ? (
+                        <div className="flex flex-col gap-1 p-2 border border-red-500/30 bg-red-500/5 rounded">
+                          <span className="text-red-400 font-medium">Vault will FAIL at lock</span>
+                          <span className="text-red-300 text-xs">
+                            LP is required but estimated ADA portion of LP (₳{formatNum(vault.projectedLpAdaAmount)}) is
+                            below minimum (₳{vault.lpMinLiquidityAda}). Vault needs more acquire contributions or will
+                            fail and refund users.
+                          </span>
+                        </div>
+                      ) : (
+                        <>
+                          <div className="flex justify-between mb-1">
+                            <span className="text-dark-100">% Liquidity Pool Contribution</span>
+                            <span className="text-white font-medium">{vault.liquidityPoolContribution}%</span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-dark-100">Current ADA LP amount:</span>
+                            <span className="text-dark-100">
+                              {currency === 'ada'
+                                ? `₳${formatNum(vault.projectedLpAdaAmount)}`
+                                : `$${formatNum(vault.projectedLpUsdAmount)}`}
+                            </span>
+                          </div>
+                          <div className="flex justify-between">
+                            <span className="text-dark-100">LP Minimum (₳{vault.lpMinLiquidityAda}):</span>
+                            <span className={lpMinThresholdMet ? 'text-green-400' : 'text-yellow-400'}>
+                              {lpMinThresholdMet ? '✓ LP Threshold met' : 'Not yet reached'}
+                            </span>
+                          </div>
+                          {!lpMinThresholdMet && (
+                            <div className="flex flex-col gap-1 p-2 border border-yellow-500/30 bg-yellow-500/5 rounded mt-1">
+                              <span className="text-yellow-300 text-xs">
+                                ⚠️ LP minimum not yet met. More acquire contributions needed to reach ₳
+                                {vault.lpMinLiquidityAda} minimum for liquidity pool creation.
+                              </span>
+                            </div>
+                          )}
+                        </>
+                      )}
+                    </div>
+                  )}
+                </>
+              ) : (
+                <div className="text-sm text-dark-100">
+                  Acquire phase active - contributions accepted until phase expires
+                </div>
+              )}
             </div>
           )
         ) : isLocked && vault.assetsPrices.totalAcquiredAda && vault.assetsPrices.totalAcquiredUsd ? (

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -55,6 +55,59 @@ const ProgressBubble = ({ value, progress }) => {
   );
 };
 
+const AcquireExpansionProgress = ({ vault, currency }) => {
+  const hasMax = !vault.acquireExpansionNoMax && vault.acquireExpansionMaxAda > 0;
+  const currentAda = vault.acquireExpansionCurrentAda || 0;
+  const currentUsd = vault.acquireExpansionCurrentUsd || 0;
+  const maxAda = vault.acquireExpansionMaxAda || 0;
+  const maxUsd = vault.acquireExpansionMaxUsd || 0;
+
+  const progress = hasMax ? calculateProgress(currentAda, maxAda) : 0;
+
+  return (
+    <div>
+      <h2 className="font-medium mb-2">Acquire Expansion:</h2>
+      {hasMax ? (
+        <>
+          <div className="flex justify-between text-sm mb-1">
+            <span className="text-dark-100">
+              Raised: {currency === 'ada' ? `₳${formatNum(currentAda)}` : `$${formatNum(currentUsd)}`}
+            </span>
+            <span className="text-dark-100">{Math.floor(progress)}%</span>
+          </div>
+          <div className="relative mb-4">
+            <LavaProgressBar
+              className="h-2 rounded-full bg-steel-750"
+              segments={[
+                {
+                  progress: Math.min(progress, 100),
+                  className: 'bg-gradient-to-r from-[#F9731600] to-[#F97316]',
+                },
+              ]}
+            />
+          </div>
+          <div className="flex justify-between w-full text-xs text-dark-100">
+            <span>min 0 ADA</span>
+            <span>max {currency === 'ada' ? `₳${formatNum(maxAda)}` : `$${formatNum(maxUsd)}`}</span>
+          </div>
+        </>
+      ) : (
+        <>
+          <div className="flex w-full justify-start gap-1 text-sm text-dark-100 mb-2">
+            Total Raised:{' '}
+            <span className="text-white font-medium">
+              {currency === 'ada' ? `₳${formatNum(currentAda)}` : `$${formatNum(currentUsd)}`}
+            </span>
+          </div>
+          <div className="text-sm text-dark-100 mb-2">
+            No ADA limit - contributions accepted until the current phase expires
+          </div>
+        </>
+      )}
+    </div>
+  );
+};
+
 const ContributionProgress = ({
   title,
   contributionProgress,
@@ -318,23 +371,7 @@ export const VaultContribution = ({ vault }) => {
             setShowMoreInfo={setShowMoreInfo}
           />
         ) : isAcquireExpansion ? (
-          <>
-            <ContributionProgress
-              title="Expansion"
-              contributionProgress={
-                vault.expansionAssetMax > 0
-                  ? calculateProgress(vault.expansionAssetsCount || 0, vault.expansionAssetMax)
-                  : 0
-              }
-              minContributeAssets={0}
-              maxContributeAssets={vault.expansionAssetMax}
-              assetList={vault.expansionAssetsByPolicy || []}
-              assetsCount={vault.expansionAssetsCount || 0}
-              assetsByPolicy={vault.expansionAssetsByPolicy || []}
-              showMoreInfo={showMoreInfo}
-              setShowMoreInfo={setShowMoreInfo}
-            />
-          </>
+          <AcquireExpansionProgress vault={vault} currency={currency} />
         ) : null}
       </div>
 

--- a/src/components/vault-profile/VaultGovernance.jsx
+++ b/src/components/vault-profile/VaultGovernance.jsx
@@ -186,7 +186,9 @@ export const VaultGovernance = ({ vault }) => {
     );
   };
 
-  const showProposalList = ['locked', 'burned', 'terminating', 'expansion'].includes(vault.vaultStatus);
+  const showProposalList = ['locked', 'burned', 'terminating', 'expansion', 'acquire_expansion'].includes(
+    vault.vaultStatus
+  );
 
   return (
     <div className="text-white min-h-screen p-6 rounded-2xl overflow-hidden">

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -304,9 +304,11 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
       contributionPhaseEndTime > Date.now() + BUTTON_DISABLE_THRESHOLD_MS &&
       !allAssetsAtMaxCapacity;
 
-    // Check if vault is in an invalid status for contributions
+    // Check if vault is in an invalid status for contributions/expansions
     const isInvalidStatus =
-      vault.vaultStatus !== VAULT_STATUSES.CONTRIBUTION && vault.vaultStatus !== VAULT_STATUSES.EXPANSION;
+      vault.vaultStatus !== VAULT_STATUSES.CONTRIBUTION &&
+      vault.vaultStatus !== VAULT_STATUSES.EXPANSION &&
+      vault.vaultStatus !== VAULT_STATUSES.ACQUIRE_EXPANSION;
 
     // Check if contribution phase is full
     const isContributionFull = vault.vaultStatus === VAULT_STATUSES.CONTRIBUTION && allAssetsAtMaxCapacity;
@@ -333,14 +335,20 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
         text: 'Acquire',
         handleClick: () => openModal('AcquireModal', { vault }),
         available:
-          vault.vaultStatus === VAULT_STATUSES.ACQUIRE &&
-          new Date(vault.acquirePhaseStart).getTime() + vault.acquireWindowDuration >
-            Date.now() + BUTTON_DISABLE_THRESHOLD_MS,
+          (vault.vaultStatus === VAULT_STATUSES.ACQUIRE &&
+            new Date(vault.acquirePhaseStart).getTime() + vault.acquireWindowDuration >
+              Date.now() + BUTTON_DISABLE_THRESHOLD_MS) ||
+          (vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION &&
+            vault.expansionPhaseStart &&
+            new Date(vault.expansionPhaseStart).getTime() + vault.expansionDuration >
+              Date.now() + BUTTON_DISABLE_THRESHOLD_MS),
       },
       Governance: {
         text: 'Create Proposal',
         available:
-          (vault.vaultStatus === VAULT_STATUSES.LOCKED || vault.vaultStatus === VAULT_STATUSES.EXPANSION) &&
+          (vault.vaultStatus === VAULT_STATUSES.LOCKED ||
+            vault.vaultStatus === VAULT_STATUSES.EXPANSION ||
+            vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION) &&
           vault.canCreateProposal,
         handleClick: () => openModal('CreateProposalModal', { vault }),
       },

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -385,52 +385,35 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
     }
   };
 
-  // Calculate vault statistics
-  const hasActiveLp = vault?.hasActiveLp;
-  const isAcquirePhase = vault?.vaultStatus === 'acquire';
-
-  const ftGains = (() => {
-    if (!hasActiveLp) return 'N/A';
-    const gainsValue = isAda ? vault.gainsAda : vault.gainsUsd;
-    if (gainsValue == null) return 'N/A';
-    const isNegative = gainsValue < 0;
-    return `${isNegative ? '-' : ''}${currencySymbol}${formatNum(Math.abs(gainsValue))}`;
-  })();
-
-  const fdv = (() => {
-    if (!hasActiveLp && !isAcquirePhase) return 'N/A';
-    const fdvValue = isAda ? vault.fdv : vault.fdvUsd;
-    if (fdvValue == null) return 'N/A';
-    return `${currencySymbol}${formatNum(fdvValue)}`;
-  })();
-
-  const fdvTvl = (() => {
-    if (!hasActiveLp && !isAcquirePhase) return 'N/A';
-    if (vault.fdvTvl == null) return 'N/A';
-    if (vault.fdvTvl < 0.01 && vault.fdvTvl > 0) return '< 0.01';
-    return vault.fdvTvl.toFixed(2);
-  })();
-
-  const vtPrice = (() => {
-    if (!hasActiveLp) return 'N/A';
-    const priceValue = isAda ? formatNum(vault.vtPrice, 4) : formatNum(vault.vtPriceUsd, 4);
-    if (priceValue == null) return 'N/A';
-    return `${currencySymbol}${priceValue}`;
-  })();
-
-  const tvl = (() => {
-    const tvlValue = isAda ? vault.assetsPrices?.totalValueAda : vault.assetsPrices?.totalValueUsd;
-    if (tvlValue == null) return 'N/A';
-    return `${currencySymbol}${formatNum(tvlValue)}`;
-  })();
-
+  // Calculate vault statistics - values computed on the backend in vault.vaultStats
   const vaultStats = {
     assetValue: vault.vaultStatus,
-    ftGains,
-    fdv,
-    fdvTvl,
-    vtPrice,
-    tvl,
+    ftGains: (() => {
+      const val = isAda ? vault.vaultStats?.ftGainsAda : vault.vaultStats?.ftGainsUsd;
+      if (val == null) return 'N/A';
+      return `${val < 0 ? '-' : ''}${currencySymbol}${formatNum(Math.abs(val))}`;
+    })(),
+    fdv: (() => {
+      const val = isAda ? vault.vaultStats?.fdvAda : vault.vaultStats?.fdvUsd;
+      if (val == null) return 'N/A';
+      return `${currencySymbol}${formatNum(val)}`;
+    })(),
+    fdvTvl: (() => {
+      const val = vault.vaultStats?.fdvTvl;
+      if (val == null) return 'N/A';
+      if (val < 0.01 && val > 0) return '< 0.01';
+      return val.toFixed(2);
+    })(),
+    vtPrice: (() => {
+      const val = isAda ? vault.vaultStats?.vtPriceAda : vault.vaultStats?.vtPriceUsd;
+      if (val == null) return 'N/A';
+      return `${currencySymbol}${formatNum(val, 4)}`;
+    })(),
+    tvl: (() => {
+      const val = isAda ? vault.vaultStats?.tvlAda : vault.vaultStats?.tvlUsd;
+      if (val == null) return 'N/A';
+      return `${currencySymbol}${formatNum(val)}`;
+    })(),
   };
 
   const renderVaultInfo = () => (
@@ -472,7 +455,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
               </div>
             )}
             {/* Statistic */}
-            {hasActiveLp && IS_MAINNET && (
+            {vault?.hasActiveLp && IS_MAINNET && (
               <div className="group relative">
                 <button
                   onClick={() => openModal('ChartModal', { vault })}
@@ -624,7 +607,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
   };
 
   const activeLpTokenOut = (() => {
-    if (!hasActiveLp) return null;
+    if (!vault?.hasActiveLp) return null;
 
     const policyId = vault?.policyId || '';
     const assetName = vault?.assetVaultName || '';

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -269,23 +269,6 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
 
   const handleTabChange = tab => setActiveTab(tab);
 
-  const isPhaseTransitioning = () => {
-    if (!vault) return false;
-    const now = Date.now();
-
-    if (vault.vaultStatus === VAULT_STATUSES.CONTRIBUTION && vault.contributionPhaseStart) {
-      const contributionEnd = new Date(vault.contributionPhaseStart).getTime() + (vault.contributionDuration || 0);
-      return now >= contributionEnd;
-    }
-
-    if (vault.vaultStatus === VAULT_STATUSES.ACQUIRE && vault.acquirePhaseStart) {
-      const acquireEnd = new Date(vault.acquirePhaseStart).getTime() + (vault.acquireWindowDuration || 0);
-      return now >= acquireEnd;
-    }
-
-    return false;
-  };
-
   const renderActionButton = () => {
     const allAssetsAtMaxCapacity = areAllAssetsAtMaxCapacity(vault.assetsWhitelist, contributedAssets, vault);
     const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
@@ -334,14 +317,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
       Token: {
         text: 'Acquire',
         handleClick: () => openModal('AcquireModal', { vault }),
-        available:
-          (vault.vaultStatus === VAULT_STATUSES.ACQUIRE &&
-            new Date(vault.acquirePhaseStart).getTime() + vault.acquireWindowDuration >
-              Date.now() + BUTTON_DISABLE_THRESHOLD_MS) ||
-          (vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION &&
-            vault.expansionPhaseStart &&
-            new Date(vault.expansionPhaseStart).getTime() + vault.expansionDuration >
-              Date.now() + BUTTON_DISABLE_THRESHOLD_MS),
+        available: vault.isAcquireWindowActive,
       },
       Governance: {
         text: 'Create Proposal',
@@ -706,7 +682,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
               countdownValue={getCountdownTime(vault)}
               color={vault.vaultStatus === 'locked' ? 'yellow' : 'red'}
             />
-            {isPhaseTransitioning() && <PhaseTransitionInfo />}
+            {vault.isPhaseTransitioning && <PhaseTransitionInfo />}
           </div>
           <div className="mb-6">{renderFailureBanner()}</div>
           {vault.vaultStatus !== 'locked' ? (

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -269,6 +269,23 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
 
   const handleTabChange = tab => setActiveTab(tab);
 
+  const isPhaseTransitioning = () => {
+    if (!vault) return false;
+    const now = Date.now();
+
+    if (vault.vaultStatus === VAULT_STATUSES.CONTRIBUTION && vault.contributionPhaseStart) {
+      const contributionEnd = new Date(vault.contributionPhaseStart).getTime() + (vault.contributionDuration || 0);
+      return now >= contributionEnd;
+    }
+
+    if (vault.vaultStatus === VAULT_STATUSES.ACQUIRE && vault.acquirePhaseStart) {
+      const acquireEnd = new Date(vault.acquirePhaseStart).getTime() + (vault.acquireWindowDuration || 0);
+      return now >= acquireEnd;
+    }
+
+    return false;
+  };
+
   const renderActionButton = () => {
     const allAssetsAtMaxCapacity = areAllAssetsAtMaxCapacity(vault.assetsWhitelist, contributedAssets, vault);
     const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
@@ -682,7 +699,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
               countdownValue={getCountdownTime(vault)}
               color={vault.vaultStatus === 'locked' ? 'yellow' : 'red'}
             />
-            {vault.isPhaseTransitioning && <PhaseTransitionInfo />}
+            {isPhaseTransitioning() && <PhaseTransitionInfo />}
           </div>
           <div className="mb-6">{renderFailureBanner()}</div>
           {vault.vaultStatus !== 'locked' ? (

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -6,11 +6,7 @@ import toast from 'react-hot-toast';
 import { SwapComponent } from '../swap/Swap';
 
 import { useCurrency } from '@/hooks/useCurrency';
-import {
-  BUTTON_DISABLE_THRESHOLD_MS,
-  VAULT_STATUSES,
-  VAULT_TAGS_OPTIONS,
-} from '@/components/vaults/constants/vaults.constants';
+import { VAULT_STATUSES, VAULT_TAGS_OPTIONS } from '@/components/vaults/constants/vaults.constants';
 import PrimaryButton from '@/components/shared/PrimaryButton';
 import { Chip } from '@/components/shared/Chip';
 import { GoldenVerifiedBadge, OFFICIAL_PARTNER_BADGE_HINT } from '@/components/shared/GoldenVerifiedBadge';
@@ -290,20 +286,6 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
     const allAssetsAtMaxCapacity = areAllAssetsAtMaxCapacity(vault.assetsWhitelist, contributedAssets, vault);
     const isExpansion = vault.vaultStatus === VAULT_STATUSES.EXPANSION;
 
-    // Check if expansion phase is active
-    const isExpansionActive =
-      isExpansion &&
-      vault.expansionPhaseStart &&
-      new Date(vault.expansionPhaseStart).getTime() + (vault.expansionDuration || 0) >
-        Date.now() + BUTTON_DISABLE_THRESHOLD_MS;
-
-    // Check if contribution phase is active and accepting contributions
-    const contributionPhaseEndTime = new Date(vault.contributionPhaseStart).getTime() + vault.contributionDuration;
-    const isContributionPhaseActive =
-      vault.vaultStatus === VAULT_STATUSES.CONTRIBUTION &&
-      contributionPhaseEndTime > Date.now() + BUTTON_DISABLE_THRESHOLD_MS &&
-      !allAssetsAtMaxCapacity;
-
     // Check if vault is in an invalid status for contributions/expansions
     const isInvalidStatus =
       vault.vaultStatus !== VAULT_STATUSES.CONTRIBUTION &&
@@ -328,7 +310,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
       Assets: {
         text: buttonText,
         handleClick: () => openModal('ContributeModal', { vault, isExpansion }),
-        available: isContributionPhaseActive || isExpansionActive,
+        available: vault.isContributionWindowActive && !allAssetsAtMaxCapacity,
         disabled: isInvalidStatus || isContributionFull || isExpansionFull,
       },
       Token: {

--- a/src/components/vault-profile/VaultSocialLinks.jsx
+++ b/src/components/vault-profile/VaultSocialLinks.jsx
@@ -2,7 +2,7 @@ import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 
 export const VaultSocialLinks = ({ socialLinks = [] }) => {
   if (socialLinks.length === 0) {
-    return <p className="text-dark-100 text-sm">No social links</p>;
+    return null;
   }
 
   return (

--- a/src/components/vault-profile/VaultStats.jsx
+++ b/src/components/vault-profile/VaultStats.jsx
@@ -1,5 +1,6 @@
 import { InfoRow } from '@/components/ui/infoRow.js';
 import { cn } from '@/lib/utils.js';
+import { formatVaultStatus } from '@/utils/core.utils.js';
 
 export const VaultStats = ({
   assetValue,
@@ -9,16 +10,6 @@ export const VaultStats = ({
   tvl = 'N/A',
   vtPrice = 'N/A',
 }) => {
-  // Format vault status for display
-  const formatVaultStatus = status => {
-    if (!status) return 'N/A';
-    // Convert snake_case to Title Case (e.g., "acquire_expansion" -> "Acquire Expansion")
-    return status
-      .split('_')
-      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
-      .join(' ');
-  };
-
   const stats = [
     {
       label: 'VAULT STAGE',

--- a/src/components/vault-profile/VaultStats.jsx
+++ b/src/components/vault-profile/VaultStats.jsx
@@ -9,10 +9,20 @@ export const VaultStats = ({
   tvl = 'N/A',
   vtPrice = 'N/A',
 }) => {
+  // Format vault status for display
+  const formatVaultStatus = status => {
+    if (!status) return 'N/A';
+    // Convert snake_case to Title Case (e.g., "acquire_expansion" -> "Acquire Expansion")
+    return status
+      .split('_')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
   const stats = [
     {
       label: 'VAULT STAGE',
-      value: assetValue ? assetValue.toUpperCase() : 'N/A',
+      value: formatVaultStatus(assetValue),
     },
     {
       label: 'VT PRICE',

--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -172,9 +172,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
         preset_id: preset.id ?? null,
         tokensForAcquires: isAcquireOnly ? 100 : (config.tokensForAcquires ?? prev.tokensForAcquires),
         acquireReserve: config.acquireReserve ?? prev.acquireReserve,
-        liquidityPoolContribution: isAcquireOnly
-          ? 0
-          : (config.liquidityPoolContribution ?? prev.liquidityPoolContribution),
+        liquidityPoolContribution: config.liquidityPoolContribution ?? prev.liquidityPoolContribution,
         creationThreshold: config.creationThreshold ?? prev.creationThreshold,
         voteThreshold: 0,
         cosigningThreshold: config.cosigningThreshold ?? prev.cosigningThreshold,
@@ -527,7 +525,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
       preset_id: selectedPreset.id ?? null,
       tokensForAcquires: isAcquireOnly ? 100 : (config.tokensForAcquires ?? null),
       acquireReserve: config.acquireReserve ?? null,
-      liquidityPoolContribution: isAcquireOnly ? 0 : (config.liquidityPoolContribution ?? null),
+      liquidityPoolContribution: config.liquidityPoolContribution ?? null,
       creationThreshold: config.creationThreshold ?? null,
       voteThreshold: 0,
       cosigningThreshold: config.cosigningThreshold ?? null,

--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -105,6 +105,11 @@ export const CreateVaultForm = ({ vault, setVault }) => {
   // Config-controlled inputs are locked unless an advanced preset exists AND is currently active
   const isPresetConfigLocked = !isAdvancedPresetAvailable || vaultData.preset !== 'advanced';
 
+  const isAcquireOnly = vaultData.preset === 'acquire_only';
+
+  // Hide the Contribute step (id=2) for acquire-only vaults — no contributors allowed
+  const visibleSteps = isAcquireOnly ? steps.filter(s => s.id !== 2) : steps;
+
   const presetOptions = useMemo(
     () =>
       Array.isArray(presets)
@@ -477,7 +482,8 @@ export const CreateVaultForm = ({ vault, setVault }) => {
     // When editing a field on a non-config step, auto-switch to the advanced preset if available.
     // Also sync vaultData.preset / preset_id so isPresetConfigLocked and handleNextStep
     // immediately reflect the advanced mode (unlocks inputs, restores step-by-step navigation).
-    if (currentStep !== 1 && isAdvancedPresetAvailable) {
+    // Do NOT auto-switch if the current preset is acquire_only — LP% is intentionally editable there.
+    if (currentStep !== 1 && isAdvancedPresetAvailable && vaultData.preset !== 'acquire_only') {
       const advancedPreset = presets.find(
         preset => preset?.type?.toLowerCase() === 'advanced' || preset?.name?.toLowerCase() === 'advanced'
       );
@@ -971,9 +977,9 @@ export const CreateVaultForm = ({ vault, setVault }) => {
     );
   };
 
-  const stepOptions = steps.map(step => ({
+  const stepOptions = visibleSteps.map((step, index) => ({
     value: step.id.toString(),
-    label: `${step.id}. ${step.title}`,
+    label: `${index + 1}. ${step.title}`,
   }));
 
   const handleStepSelect = stepId => {
@@ -1027,9 +1033,11 @@ export const CreateVaultForm = ({ vault, setVault }) => {
               <p className="text-sm text-dark-100 uppercase font-russo">
                 {isStepFullyComplete(currentStep, vaultData) ? 'completed' : 'in progress'}
               </p>
-              <p className="text-lg font-bold text-white">{steps.find(step => step.id === currentStep)?.title || ''}</p>
+              <p className="text-lg font-bold text-white">
+                {visibleSteps.find(step => step.id === currentStep)?.title || ''}
+              </p>
             </div>
-            {steps.find(step => step.id === currentStep)?.hasErrors && (
+            {visibleSteps.find(step => step.id === currentStep)?.hasErrors && (
               <div className="w-8 h-8 bg-red-600 rounded-full flex items-center justify-center">
                 <span className="text-white font-bold">!</span>
               </div>
@@ -1038,7 +1046,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
         </div>
       </div>
       <div className="hidden md:flex relative items-center mb-8">
-        {steps.map((step, index) => (
+        {visibleSteps.map((step, index) => (
           <div key={`step-${step.id}`} className="flex-1 flex flex-col items-center relative">
             <button
               className="focus:outline-none flex flex-col items-center"
@@ -1051,12 +1059,12 @@ export const CreateVaultForm = ({ vault, setVault }) => {
                 </div>
               )}
               <div className="relative z-10">
-                <LavaStepCircle isActive={currentStep === step.id} number={step.id} status={step.status} />
+                <LavaStepCircle isActive={currentStep === step.id} number={index + 1} status={step.status} />
               </div>
               <p className="uppercase font-russo text-sm text-dark-100 mt-8">{step.status}</p>
               <p className="font-bold text-2xl whitespace-nowrap">{step.title}</p>
             </button>
-            {index < steps.length - 1 && (
+            {index < visibleSteps.length - 1 && (
               <div
                 className={`absolute top-[25%] -right-[15%] lg:-right-[25%] w-[30%] lg:w-[45%] h-[3px] 
                   ${step.id < currentStep ? 'bg-gradient-to-r from-yellow-400 to-orange-500' : 'bg-white/10'}

--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -165,17 +165,21 @@ export const CreateVaultForm = ({ vault, setVault }) => {
     const applyPresetData = preset => {
       if (!preset) return;
       const config = preset.config || {};
+      const isAcquireOnly = preset.type?.toLowerCase() === 'acquire_only';
       setVaultData(prev => ({
         ...prev,
         preset: preset.type || 'advanced',
         preset_id: preset.id ?? null,
-        tokensForAcquires: config.tokensForAcquires ?? prev.tokensForAcquires,
+        tokensForAcquires: isAcquireOnly ? 100 : (config.tokensForAcquires ?? prev.tokensForAcquires),
         acquireReserve: config.acquireReserve ?? prev.acquireReserve,
-        liquidityPoolContribution: config.liquidityPoolContribution ?? prev.liquidityPoolContribution,
+        liquidityPoolContribution: isAcquireOnly
+          ? 0
+          : (config.liquidityPoolContribution ?? prev.liquidityPoolContribution),
         creationThreshold: config.creationThreshold ?? prev.creationThreshold,
         voteThreshold: 0,
         cosigningThreshold: config.cosigningThreshold ?? prev.cosigningThreshold,
         executionThreshold: config.executionThreshold ?? prev.executionThreshold,
+        isAcquireOnly,
       }));
       setSelectedPresetId(preset.id.toString());
     };
@@ -191,6 +195,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
             ...prev,
             preset: foundPreset.type || 'advanced',
             preset_id: foundPreset.id ?? null,
+            isAcquireOnly: foundPreset.type?.toLowerCase() === 'acquire_only',
           }));
         } else {
           // The preset was deleted — fall back to the first available preset
@@ -261,15 +266,31 @@ export const CreateVaultForm = ({ vault, setVault }) => {
 
   const handleNextStep = async () => {
     if (currentStep < steps.length) {
+      const isAcquireOnly = vaultData.preset === 'acquire_only';
       const isAdvancedMode = isAdvancedPresetAvailable && vaultData.preset === 'advanced';
-      const nextStep = isAdvancedMode ? currentStep + 1 : steps.length;
+      let nextStep;
+      if (isAdvancedMode || isAcquireOnly) {
+        nextStep = currentStep + 1;
+        // Skip contribution step for acquire-only vaults
+        if (isAcquireOnly && nextStep === 2) {
+          nextStep = 3;
+        }
+      } else {
+        nextStep = steps.length;
+      }
       await changeStep(nextStep);
     }
   };
 
   const handlePreviousStep = async () => {
     if (currentStep > 1) {
-      await changeStep(currentStep - 1, true);
+      const isAcquireOnly = vaultData.preset === 'acquire_only';
+      let prevStep = currentStep - 1;
+      // Skip contribution step for acquire-only vaults
+      if (isAcquireOnly && prevStep === 2) {
+        prevStep = 1;
+      }
+      await changeStep(prevStep, true);
     }
   };
 
@@ -487,11 +508,14 @@ export const CreateVaultForm = ({ vault, setVault }) => {
     const isAdvanced =
       selectedPreset?.type?.toLowerCase() === 'advanced' || selectedPreset?.name?.toLowerCase() === 'advanced';
 
+    const isAcquireOnly = selectedPreset?.type?.toLowerCase() === 'acquire_only';
+
     if (isAdvanced) {
       setVaultData(prev => ({
         ...prev,
         preset: selectedPreset.type || 'advanced',
         preset_id: selectedPreset.id ?? null,
+        isAcquireOnly: false,
       }));
       return;
     }
@@ -501,13 +525,16 @@ export const CreateVaultForm = ({ vault, setVault }) => {
       ...prev,
       preset: selectedPreset.type || prev.preset,
       preset_id: selectedPreset.id ?? null,
-      tokensForAcquires: config.tokensForAcquires ?? null,
+      tokensForAcquires: isAcquireOnly ? 100 : (config.tokensForAcquires ?? null),
       acquireReserve: config.acquireReserve ?? null,
-      liquidityPoolContribution: config.liquidityPoolContribution ?? null,
+      liquidityPoolContribution: isAcquireOnly ? 0 : (config.liquidityPoolContribution ?? null),
       creationThreshold: config.creationThreshold ?? null,
       voteThreshold: 0,
       cosigningThreshold: config.cosigningThreshold ?? null,
       executionThreshold: config.executionThreshold ?? null,
+      isAcquireOnly,
+      // Reset minAcquireThreshold when switching away from acquire-only
+      minAcquireThreshold: isAcquireOnly ? (prev.minAcquireThreshold ?? null) : null,
     }));
   };
 
@@ -624,6 +651,8 @@ export const CreateVaultForm = ({ vault, setVault }) => {
 
   const handleStepClick = async stepId => {
     if (stepId === currentStep) return;
+    // Prevent navigating to the contribution step for acquire-only vaults
+    if (stepId === 2 && vaultData.preset === 'acquire_only') return;
     const skipValidation = stepId < currentStep;
     await changeStep(stepId, skipValidation);
     scrollToTop();

--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
 import { GoldenVerifiedBadge, OFFICIAL_PARTNER_BADGE_HINT } from '@/components/shared/GoldenVerifiedBadge';
 import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
-import { formatCompactNumber, formatString } from '@/utils/core.utils';
+import { formatCompactNumber, formatString, formatVaultStatus } from '@/utils/core.utils';
 import { VaultShortResponse } from '@/utils/types';
 import { useCurrency } from '@/hooks/useCurrency';
 import L4vaIcon from '@/icons/l4va.svg?react';
@@ -90,7 +90,7 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
             </div>
             <div>
               <p className="text-sm text-dark-100">Stage</p>
-              <p className="capitalize font-bold">{vault.vaultStatus}</p>
+              <p className="font-bold">{formatVaultStatus(vault.vaultStatus)}</p>
             </div>
           </div>
         </div>

--- a/src/components/vaults/VaultListItem.tsx
+++ b/src/components/vaults/VaultListItem.tsx
@@ -4,7 +4,7 @@ import { useMemo } from 'react';
 import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
 import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 import { InfoRow } from '@/components/ui/infoRow';
-import { formatCompactNumber } from '@/utils/core.utils';
+import { formatCompactNumber, formatVaultStatus } from '@/utils/core.utils';
 import { VaultShortResponse } from '@/utils/types';
 import L4vaIcon from '@/icons/l4va.svg?react';
 
@@ -64,7 +64,7 @@ const VaultListItem = ({ vault }: VaultListItemProps) => {
 
           <div className="hidden md:block">
             <p className="text-sm text-dark-100">Stage</p>
-            <p className="font-bold capitalize">{vault.vaultStatus}</p>
+            <p className="font-bold">{formatVaultStatus(vault.vaultStatus)}</p>
           </div>
           {shouldShowCountdown && (
             <div className="hidden md:block">

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -283,7 +283,11 @@ export const vaultSchema = yup.object({
   contributionOpenWindowType: yup
     .string()
     .oneOf(['custom', 'upon-vault-launch'], 'Invalid contribution window type')
-    .required('Contribution window type is required'),
+    .when('isAcquireOnly', {
+      is: true,
+      then: schema => schema.nullable().notRequired(),
+      otherwise: schema => schema.required('Contribution window type is required'),
+    }),
   contributionOpenWindowTime: yup
     .number()
     .typeError('Time is required')
@@ -295,16 +299,41 @@ export const vaultSchema = yup.object({
   assetsWhitelist: yup
     .array()
     .of(assetWhitelistItemSchema)
-    .required('Assets whitelist is required')
-    .min(1, 'Assets whitelist must have at least 1 item')
-    .max(10, 'Assets whitelist can have a maximum of 10 items')
-    .default([]),
+    .default([])
+    .when('isAcquireOnly', {
+      is: true,
+      then: schema => schema.notRequired(),
+      otherwise: schema =>
+        schema
+          .required('Assets whitelist is required')
+          .min(1, 'Assets whitelist must have at least 1 item')
+          .max(10, 'Assets whitelist can have a maximum of 10 items'),
+    }),
   contributionDuration: yup
     .number()
     .typeError('Duration is required')
-    .required('Duration is required')
-    .min(MIN_CONTRIBUTION_DURATION_MS, 'Duration must be at least 5 days')
-    .max(MAX_CONTRIBUTION_DURATION_MS, 'Duration cannot exceed 30 days'),
+    .when('isAcquireOnly', {
+      is: true,
+      then: schema => schema.nullable().notRequired(),
+      otherwise: schema =>
+        schema
+          .required('Duration is required')
+          .min(MIN_CONTRIBUTION_DURATION_MS, 'Duration must be at least 5 days')
+          .max(MAX_CONTRIBUTION_DURATION_MS, 'Duration cannot exceed 30 days'),
+    }),
+  isAcquireOnly: yup.boolean().default(false),
+  minAcquireThreshold: yup
+    .number()
+    .typeError('Minimum ADA threshold must be a number')
+    .when('isAcquireOnly', {
+      is: true,
+      then: schema =>
+        schema
+          .required('Minimum ADA threshold is required')
+          .positive('Must be a positive number')
+          .integer('Must be a whole number of ADA'),
+      otherwise: schema => schema.nullable(),
+    }),
 
   // Step 3: Acquire Window
   acquireWindowDuration: yup
@@ -543,6 +572,8 @@ export const initialVaultState = {
   tokensForAcquires: null,
   acquireReserve: null,
   liquidityPoolContribution: null,
+  isAcquireOnly: false,
+  minAcquireThreshold: null, // in ADA (converted to lovelace before API call)
 
   // Step 4: Governance
   ftTokenSupply: MIN_SUPPLY,
@@ -591,6 +622,7 @@ export const stepFields = {
     'tokensForAcquires',
     'acquireReserve',
     'liquidityPoolContribution',
+    'minAcquireThreshold',
   ],
   4: ['ftTokenSupply', 'terminationType', 'creationThreshold', 'cosigningThreshold', 'executionThreshold'],
   5: [],

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -11,8 +11,6 @@ export const MAX_ACQUIRE_WINDOW_DURATION_MS = 2592000000; // 30 days
 export const MIN_TIME_FOR_VOTING = 86400000; // 1 Day
 export const MAX_TIME_FOR_VOTING = 259200000; // 3 days
 
-export const BUTTON_DISABLE_THRESHOLD_MS = 120000; // Min 2 min before button is enabled
-
 const environment = import.meta.env.VITE_CARDANO_NETWORK;
 
 // Cardano address regex based on environment

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -42,6 +42,7 @@ export const VAULT_STATUSES = {
   ACQUIRE: 'acquire',
   LOCKED: 'locked',
   EXPANSION: 'expansion',
+  ACQUIRE_EXPANSION: 'acquire_expansion',
   TERMINATING: 'terminating',
   FAILED: 'failed',
 };

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -575,6 +575,7 @@ export const initialVaultState = {
   liquidityPoolContribution: null,
   isAcquireOnly: false,
   minAcquireThreshold: null, // in ADA (converted to lovelace before API call)
+  allowAcquireExpansion: false,
 
   // Step 4: Governance
   ftTokenSupply: MIN_SUPPLY,
@@ -607,6 +608,7 @@ export const stepFields = {
     'assetsWhitelist',
     'contributorWhitelist',
     'acquirerWhitelist',
+    'allowAcquireExpansion',
   ],
   2: [
     'valueMethod',

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -325,14 +325,11 @@ export const vaultSchema = yup.object({
   isAcquireOnly: yup.boolean().default(false),
   minAcquireThreshold: yup
     .number()
+    .nullable()
     .typeError('Minimum ADA threshold must be a number')
     .when('isAcquireOnly', {
       is: true,
-      then: schema =>
-        schema
-          .required('Minimum ADA threshold is required')
-          .positive('Must be a positive number')
-          .integer('Must be a whole number of ADA'),
+      then: schema => schema.positive('Must be a positive number').integer('Must be a whole number of ADA'),
       otherwise: schema => schema.nullable(),
     }),
 
@@ -625,7 +622,6 @@ export const stepFields = {
     'tokensForAcquires',
     'acquireReserve',
     'liquidityPoolContribution',
-    'minAcquireThreshold',
   ],
   4: ['ftTokenSupply', 'terminationType', 'creationThreshold', 'cosigningThreshold', 'executionThreshold'],
   5: [],

--- a/src/components/vaults/steps/AcquireWindow.jsx
+++ b/src/components/vaults/steps/AcquireWindow.jsx
@@ -134,7 +134,7 @@ export const AcquireWindow = ({
           <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-steel-800 border border-steel-700 text-dark-100 text-xs font-russo uppercase">
             <Lock className="w-3.5 h-3.5 flex-shrink-0" />
             {isAcquireOnly
-              ? 'Acquire-Only: Tokens for Acquirers is fixed at 100% and LP is 0%'
+              ? 'Acquire-Only: Tokens for Acquirers is fixed at 100%'
               : isAdvancedPresetAvailable
                 ? 'Values set by preset — select Advanced preset to customise'
                 : 'Advanced mode is disabled — values are managed by the preset'}
@@ -193,7 +193,7 @@ export const AcquireWindow = ({
                   : ''
             }
             onChange={handleChange}
-            disabled={isPresetConfigLocked}
+            disabled={isAcquireOnly ? false : isPresetConfigLocked}
             hint={LIQUIDITY_POOL_CONTRIBUTION_HINT}
           />
           {data.liquidityPoolContribution === 0 && (

--- a/src/components/vaults/steps/AcquireWindow.jsx
+++ b/src/components/vaults/steps/AcquireWindow.jsx
@@ -103,11 +103,10 @@ export const AcquireWindow = ({
         {isAcquireOnly && (
           <div>
             <Label className="uppercase font-bold" htmlFor="minAcquireThreshold">
-              *MINIMUM ADA THRESHOLD
+              MINIMUM ADA THRESHOLD (OPTIONAL)
             </Label>
             <div className="mt-4">
               <LavaInput
-                required
                 error={errors.minAcquireThreshold}
                 label=""
                 id="minAcquireThreshold"
@@ -124,7 +123,7 @@ export const AcquireWindow = ({
                   const raw = e.target.value.replace(/[^0-9]/g, '');
                   updateField('minAcquireThreshold', raw === '' ? null : Number(raw));
                 }}
-                hint="The minimum total ADA that must be received during the acquire window for this vault to lock. If not met, the vault fails and all ADA is refunded."
+                hint="Optional. If set, the vault will only lock if this minimum amount of ADA is acquired. If not set, the vault will lock if ANY amount of ADA is acquired. If no ADA is acquired, the vault will fail and all ADA is refunded."
               />
             </div>
           </div>

--- a/src/components/vaults/steps/AcquireWindow.jsx
+++ b/src/components/vaults/steps/AcquireWindow.jsx
@@ -19,6 +19,8 @@ export const AcquireWindow = ({
   isPresetConfigLocked = false,
   isAdvancedPresetAvailable = true,
 }) => {
+  const isAcquireOnly = data.isAcquireOnly === true;
+
   const handleChange = e => {
     const { name, value } = e.target;
     const numericValue = value.replace(/[^0-9.]/g, '');
@@ -98,14 +100,45 @@ export const AcquireWindow = ({
             )}
           </div>
         </div>
+        {isAcquireOnly && (
+          <div>
+            <Label className="uppercase font-bold" htmlFor="minAcquireThreshold">
+              *MINIMUM ADA THRESHOLD
+            </Label>
+            <div className="mt-4">
+              <LavaInput
+                required
+                error={errors.minAcquireThreshold}
+                label=""
+                id="minAcquireThreshold"
+                name="minAcquireThreshold"
+                placeholder="e.g. 10000"
+                suffix="ADA"
+                type="text"
+                value={
+                  data.minAcquireThreshold !== null && data.minAcquireThreshold !== undefined
+                    ? String(data.minAcquireThreshold)
+                    : ''
+                }
+                onChange={e => {
+                  const raw = e.target.value.replace(/[^0-9]/g, '');
+                  updateField('minAcquireThreshold', raw === '' ? null : Number(raw));
+                }}
+                hint="The minimum total ADA that must be received during the acquire window for this vault to lock. If not met, the vault fails and all ADA is refunded."
+              />
+            </div>
+          </div>
+        )}
       </div>
       <div className="space-y-12 min-w-0">
-        {isPresetConfigLocked && (
+        {(isPresetConfigLocked || isAcquireOnly) && (
           <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-steel-800 border border-steel-700 text-dark-100 text-xs font-russo uppercase">
             <Lock className="w-3.5 h-3.5 flex-shrink-0" />
-            {isAdvancedPresetAvailable
-              ? 'Values set by preset — select Advanced preset to customise'
-              : 'Advanced mode is disabled — values are managed by the preset'}
+            {isAcquireOnly
+              ? 'Acquire-Only: Tokens for Acquirers is fixed at 100% and LP is 0%'
+              : isAdvancedPresetAvailable
+                ? 'Values set by preset — select Advanced preset to customise'
+                : 'Advanced mode is disabled — values are managed by the preset'}
           </div>
         )}
         <div>
@@ -119,15 +152,9 @@ export const AcquireWindow = ({
             type="text"
             value={data.tokensForAcquires === 0 ? '0' : data.tokensForAcquires ? String(data.tokensForAcquires) : ''}
             onChange={handleChange}
-            disabled={isPresetConfigLocked}
+            disabled={isPresetConfigLocked || isAcquireOnly}
             hint="The percentage (%) of net vault tokens minted (total vault tokens minus LP Contribution) which will be received by Acquirers when vault locks."
           />
-          {data.tokensForAcquires === 0 && (
-            <p className="text-orange-500 mt-1">
-              Warning: 0% Tokens for Acquirers means this vault will NOT be offered to acquirers to send ADA and Reserve
-              % will not apply.
-            </p>
-          )}
         </div>
         <div>
           <LavaInput
@@ -141,9 +168,9 @@ export const AcquireWindow = ({
             value={data.acquireReserve === 0 ? '0' : data.acquireReserve ? String(data.acquireReserve) : ''}
             onChange={handleChange}
             hint={RESERVE_HINT}
-            disabled={isPresetConfigLocked || data.tokensForAcquires === 0}
+            disabled={isPresetConfigLocked || isAcquireOnly || data.tokensForAcquires === 0}
           />
-          {data.acquireReserve < 100 && data.tokensForAcquires > 0 && (
+          {!isAcquireOnly && data.acquireReserve < 100 && data.tokensForAcquires > 0 && (
             <p className="text-orange-500 mt-1">
               Warning: Reserve % of &lt; 100% means that assets contributed will be valued at less than 100% of market
               price (floor price for NFTs / spot price for CNTs at end of Contribution window).
@@ -167,10 +194,10 @@ export const AcquireWindow = ({
                   : ''
             }
             onChange={handleChange}
-            disabled={isPresetConfigLocked}
+            disabled={isPresetConfigLocked || isAcquireOnly}
             hint={LIQUIDITY_POOL_CONTRIBUTION_HINT}
           />
-          {data.liquidityPoolContribution === 0 && (
+          {!isAcquireOnly && data.liquidityPoolContribution === 0 && (
             <p className="text-orange-500 mt-1">
               Warning: 0% LP Contribution means there will NOT be a liquidity pool launched for this Vault.
             </p>

--- a/src/components/vaults/steps/AcquireWindow.jsx
+++ b/src/components/vaults/steps/AcquireWindow.jsx
@@ -193,10 +193,10 @@ export const AcquireWindow = ({
                   : ''
             }
             onChange={handleChange}
-            disabled={isPresetConfigLocked || isAcquireOnly}
+            disabled={isPresetConfigLocked}
             hint={LIQUIDITY_POOL_CONTRIBUTION_HINT}
           />
-          {!isAcquireOnly && data.liquidityPoolContribution === 0 && (
+          {data.liquidityPoolContribution === 0 && (
             <p className="text-orange-500 mt-1">
               Warning: 0% LP Contribution means there will NOT be a liquidity pool launched for this Vault.
             </p>

--- a/src/components/vaults/steps/ConfigureVault.jsx
+++ b/src/components/vaults/steps/ConfigureVault.jsx
@@ -4,6 +4,7 @@ import { LavaSocialLinks } from '@/components/shared/LavaSocialLinks';
 import { LavaInput } from '@/components/shared/LavaInput';
 import { LavaTextarea } from '@/components/shared/LavaTextarea';
 import { LavaSelect } from '@/components/shared/LavaSelect';
+import { LavaCheckbox } from '@/components/shared/LavaCheckbox';
 import { Chip } from '@/components/shared/Chip';
 import { LavaWhitelistWithCaps } from '@/components/shared/LavaWhitelistWithCaps';
 import { LavaWhitelist } from '@/components/shared/LavaWhitelist';
@@ -101,6 +102,16 @@ export const ConfigureVault = ({
             />
             {errors.privacy && <p className="text-red-600 mt-2 text-sm">{errors.privacy}</p>}
           </div>
+        </div>
+
+        <div>
+          <LavaCheckbox
+            name="allowAcquireExpansion"
+            checked={data.allowAcquireExpansion || false}
+            onChange={e => updateField('allowAcquireExpansion', e.target.checked)}
+            label="Allow Acquire Expansion"
+            description="If enabled, vault token holders can create governance proposals to open additional acquire windows (ADA → Vault Token minting) after the vault is locked."
+          />
         </div>
 
         <div>

--- a/src/components/vaults/utils/vaults.utils.js
+++ b/src/components/vaults/utils/vaults.utils.js
@@ -6,5 +6,10 @@ export const formatVaultData = vaultData => {
     formattedData.socialLinks = formattedData.socialLinks.map(({ id, ...rest }) => rest);
   }
 
+  // Convert minAcquireThreshold from ADA to lovelace for the API
+  if (formattedData.isAcquireOnly && formattedData.minAcquireThreshold != null) {
+    formattedData.minAcquireThreshold = Math.round(Number(formattedData.minAcquireThreshold) * 1000000);
+  }
+
   return formattedData;
 };

--- a/src/constants/proposalMessages.js
+++ b/src/constants/proposalMessages.js
@@ -11,6 +11,8 @@ export const PROPOSAL_EXECUTION_MESSAGES = {
     buy_sell: 'Marketplace transactions are being prepared and executed...',
     staking: 'Staking transaction is being prepared and executed...',
     termination: 'Termination process is being prepared and executed...',
+    expansion: 'Vault expansion is being prepared and executed...',
+    acquire_expansion: 'Acquire expansion is being prepared and executed...',
     default: 'Proposal actions are being prepared and executed...',
   },
 
@@ -19,6 +21,8 @@ export const PROPOSAL_EXECUTION_MESSAGES = {
     burning: 'Assets have been successfully burned and removed from the vault.',
     distribution: 'ADA has been successfully distributed to all eligible VT holders.',
     staking: 'Assets have been successfully staked according to the proposal.',
+    expansion: 'Vault expansion has been successfully opened. New assets can now be contributed.',
+    acquire_expansion: 'Acquire expansion has been successfully opened. The vault is now accepting ADA contributions.',
     termination: {
       default: 'Vault termination has been successfully completed.',
       dao: 'Vault has been successfully terminated by governance vote.',

--- a/src/utils/core.utils.js
+++ b/src/utils/core.utils.js
@@ -303,6 +303,20 @@ export const formatString = string => {
   return `${string.substring(0, 3)}...${string.substring(length - 3)}`;
 };
 
+/**
+ * Format vault status from snake_case to Title Case
+ * @param {string} status - The vault status (e.g., "acquire_expansion")
+ * @returns {string} - Formatted status (e.g., "Acquire Expansion")
+ */
+export const formatVaultStatus = status => {
+  if (!status) return 'N/A';
+  // Convert snake_case to Title Case (e.g., "acquire_expansion" -> "Acquire Expansion")
+  return status
+    .split('_')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+};
+
 export const getDisplayName = user => {
   const { name, address } = user;
   if (name) {

--- a/src/utils/core.utils.js
+++ b/src/utils/core.utils.js
@@ -667,6 +667,13 @@ const VAULT_STATUS_CONFIG = {
     buttonText: 'Contribute',
     isCountdownActive: true,
   },
+  acquire_expansion: {
+    countdownName: 'Acquire Expansion ends in:',
+    getCountdownTime: vault =>
+      vault.expansionPhaseStart ? new Date(vault.expansionPhaseStart).getTime() + vault.expansionDuration : Date.now(),
+    buttonText: 'Acquire',
+    isCountdownActive: true,
+  },
   created: {
     countdownName: 'Contribution starts in:',
     getCountdownTime: vault => new Date(vault.contributionOpenWindowTime).getTime(),

--- a/src/utils/core.utils.js
+++ b/src/utils/core.utils.js
@@ -705,6 +705,11 @@ const VAULT_STATUS_CONFIG = {
 export const getCountdownName = vault => {
   const status = vault?.vaultStatus?.toLowerCase();
 
+  // Acquire-only vaults skip contribution — show "Acquire starts in:" instead
+  if (vault?.isAcquireOnly && (status === 'published' || status === 'created')) {
+    return 'Acquire starts in:';
+  }
+
   // Only check for custom acquire window if vault is in contribution status
   if (status === 'contribution') {
     const contributionEnd = new Date(vault.contributionPhaseStart).getTime() + vault.contributionDuration;

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -42,6 +42,7 @@ export enum VaultStatus {
   GOVERNANCE = 'governance',
   FAILED = 'failed',
   EXPANSION = 'expansion',
+  ACQUIRE_EXPANSION = 'acquire_expansion',
 }
 
 export enum ProposalType {

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -52,6 +52,7 @@ export enum ProposalType {
   BUY_SELL = 'buy_sell',
   MARKETPLACE_ACTION = 'marketplace_action',
   EXPANSION = 'expansion',
+  ACQUIRE_EXPANSION = 'acquire_expansion',
 }
 
 export const ProposalTypeLabels = {
@@ -62,6 +63,7 @@ export const ProposalTypeLabels = {
   [ProposalType.BUY_SELL]: 'Buy/Sell',
   [ProposalType.MARKETPLACE_ACTION]: 'Market Actions',
   [ProposalType.EXPANSION]: 'Vault Expansion',
+  [ProposalType.ACQUIRE_EXPANSION]: 'Acquire Expansion',
 };
 
 export enum ClaimStatus {


### PR DESCRIPTION
This pull request introduces support for a new "Acquire Expansion" proposal type, enabling vaults to reopen for new ADA contributions with flexible configuration options. It also refines the logic for enabling/disabling action buttons based on new vault window state properties and corrects the calculation and display of estimated ADA received during contributions. Additionally, it removes some unused constants and improves code clarity in related modals.

**New Acquire Expansion Proposal Feature:**

* Added the new `AcquireExpansion` component, allowing users to configure expansion duration, maximum ADA, and pricing model (market or limit) for acquire expansions, with comprehensive validation and user guidance.
* Integrated "Acquire Expansion" as a selectable execution option in the `CreateProposalModal`, including UI, payload handling, and fee assignment. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R17) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R37) [[3]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R77) [[4]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R173-R179) [[5]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R465-R467)

**Button Enable/Disable Logic Improvements:**

* Updated contribution and acquire modals to use new `isContributionWindowActive` and `isAcquireWindowActive` properties on the `vault` object for enabling/disabling action buttons, replacing previous time-based logic and removing the unused `BUTTON_DISABLE_THRESHOLD_MS` constant. [[1]](diffhunk://#diff-0bac1e55d423b90e1998b0fdd22b470d61c83c9a3ae7bf7c1a53950796d4d72aL6-L7) [[2]](diffhunk://#diff-0bac1e55d423b90e1998b0fdd22b470d61c83c9a3ae7bf7c1a53950796d4d72aL250-R248) [[3]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL11) [[4]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL315-R317)

**Contribution Modal Calculation and Display Fixes:**

* Corrected the formula for estimating ADA received by contributors to reflect the actual distribution based on acquirers and LP allocation, and ensured the value is only shown when an acquire phase exists. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL170-R176) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL442-R439)

**UI/UX and Documentation Enhancements:**

* Added a helpful hint for the new "acquire_only" vault type in the `LavaRadio` component for improved user guidance.

**Other Minor Code Cleanups:**

* Removed unused imports and constants related to button disabling thresholds from modal components for improved maintainability. [[1]](diffhunk://#diff-0bac1e55d423b90e1998b0fdd22b470d61c83c9a3ae7bf7c1a53950796d4d72aL6-L7) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL11)