### PR TITLE
Add linkSearch functionality for conditional navigation in Vault components

### DIFF
--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -32,9 +32,16 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
     return isLessThanOneDay && isLessThanTenPercent;
   }, [vault.phaseStartTime, vault.phaseEndTime, vault.timeRemaining]);
 
+  const linkSearch = useMemo(() => {
+    if (vault.vaultStatus === 'acquire' || vault.vaultStatus === 'acquire_expansion') {
+      return { tab: 'Token' };
+    }
+    return undefined;
+  }, [vault.vaultStatus]);
+
   return (
     <div className="w-full max-w-md rounded-xl bg-steel-950 overflow-hidden flex flex-col">
-      <Link className="block flex-1 flex flex-col" to={`/vaults/${id}`}>
+      <Link className="block flex-1 flex flex-col" to={`/vaults/${id}`} search={linkSearch}>
         <div className="relative h-52">
           {vaultImage ? (
             <img alt="Vault avatar" className="h-full w-full object-cover" src={vaultImage} loading="lazy" />

--- a/src/components/vaults/VaultListItem.tsx
+++ b/src/components/vaults/VaultListItem.tsx
@@ -30,9 +30,16 @@ const VaultListItem = ({ vault }: VaultListItemProps) => {
     return isLessThanOneDay && isLessThanTenPercent;
   }, [vault.phaseStartTime, vault.phaseEndTime, vault.timeRemaining]);
 
+  const linkSearch = useMemo(() => {
+    if (vault.vaultStatus === 'acquire' || vault.vaultStatus === 'acquire_expansion') {
+      return { tab: 'Token' };
+    }
+    return undefined;
+  }, [vault.vaultStatus]);
+
   return (
     <div className="relative mb-6">
-      <Link className="block" to={`/vaults/${id}`}>
+      <Link className="block" to={`/vaults/${id}`} search={linkSearch}>
         <div className="hidden md:block absolute bottom-9 left-2.5 w-[98px] h-[98px] rounded-2xl overflow-hidden">
           {vaultImage ? (
             <img alt={`${name} vault avatar`} src={vaultImage} className="object-cover w-full h-full" />


### PR DESCRIPTION
This pull request updates the navigation behavior for vault links in both the `VaultCard` and `VaultListItem` components. Now, when a vault is in the "acquire" or "acquire_expansion" status, clicking the link will include a search parameter to direct users to the "Token" tab of the vault page.

Navigation improvements:

* Updated the `VaultCard` and `VaultListItem` components to include a `search` parameter (`{ tab: 'Token' }`) in the `Link` component when the vault status is either `'acquire'` or `'acquire_expansion'`, ensuring users are directed to the correct tab based on vault status. [[1]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffR35-R44) [[2]](diffhunk://#diff-b92262fc2dd71d1ce22a89717a04009ca3d20f1fceacdfb30be5b7b83fe7a416R33-R42)