### PR TITLE
Remove unused interval options from IntervalSelector component

### DIFF
--- a/src/components/shared/IntervalSelector.jsx
+++ b/src/components/shared/IntervalSelector.jsx
@@ -3,8 +3,6 @@ import clsx from 'clsx';
 const INTERVALS = [
   { value: '1h', label: '1H' },
   { value: '1d', label: '1D' },
-  { value: '1w', label: '1W' },
-  { value: '1M', label: '1M' },
 ];
 
 export const IntervalSelector = ({ activeInterval, onIntervalChange, className = '' }) => {


### PR DESCRIPTION
This pull request makes a small update to the `IntervalSelector` component by removing the '1W' (1 week) and '1M' (1 month) interval options. This simplifies the interval selection to just '1H' (1 hour) and '1D' (1 day).