### PR TITLE
UPDATED: contribution fees

### DIFF
--- a/src/components/modals/AcquireModal.jsx
+++ b/src/components/modals/AcquireModal.jsx
@@ -255,11 +255,11 @@ export const AcquireModal = ({ vault, onClose }) => {
               <div className="text-xs text-dark-100">
                 Transaction cost:{' '}
                 <span className="text-white font-medium">
-                  ~{((vault.protocolContributorsFeeAda || 0) + 1.72).toFixed(2)} ADA
+                  ~{((vault.protocolAcquiresFeeAda || 0) + 1.72).toFixed(2)} ADA
                 </span>{' '}
                 (
-                {vault.protocolContributorsFeeAda > 0
-                  ? `${vault.protocolContributorsFeeAda?.toFixed(2)} ADA Protocol fees + ~1.72 ADA Network fees`
+                {vault.protocolAcquiresFeeAda > 0
+                  ? `${vault.protocolAcquiresFeeAda?.toFixed(2)} ADA Protocol fees + ~1.72 ADA Network fees`
                   : '~1.72 ADA Network fees'}
                 )
               </div>

--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -14,6 +14,7 @@ import { useInfiniteWalletAssets } from '@/hooks/useInfiniteWalletAssets.ts';
 import { AssetsList } from '@/components/modals/AssetsList/AssetsList.jsx';
 import { useCurrency } from '@/hooks/useCurrency';
 import { getDecimalAdjustedQuantity, getRawQuantity } from '@/utils/core.utils';
+import { estimateContributionTransactionCost } from '@/utils/contributionTransactionCost.js';
 
 const MAX_NFT_PER_TRANSACTION = 10;
 const MAX_FT_PER_TRANSACTION = 10;
@@ -174,6 +175,22 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
 
   const estimatedTickerVal = hasSelectedAssets ? userEstimatedTokens.toLocaleString() : '0';
 
+  // Protocol fee: each selected NFT or FT type counts as 1 (FT quantity ignored)
+  const feeAssetCount = selectedNFTs.length;
+
+  const feePerAssetAda = vault.protocolFeePerAssetAda || 0;
+
+  const transactionCostEstimate = useMemo(
+    () =>
+      estimateContributionTransactionCost({
+        assetCount: feeAssetCount,
+        protocolFeePerAssetAda: feePerAssetAda,
+      }),
+    [feeAssetCount, feePerAssetAda]
+  );
+
+  const totalProtocolFeeAda = transactionCostEstimate.protocolFeeAda;
+
   // Estimated ADA to Receive (only shown when acquire phase exists)
   // Contributors receive ADA from acquirers (minus LP allocation)
   // Formula: Estimated Value × (Tokens for Acquirers % - LP ADA %)
@@ -333,15 +350,18 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
           </div>
         </div>
         <div className="text-xs text-dark-100 border-t border-steel-800 pt-2">
-          Transaction cost:{' '}
-          <span className="text-white font-medium">
-            ~{((vault.protocolContributorsFeeAda || 0) + 1.72).toFixed(2)} ADA
-          </span>{' '}
-          (
-          {vault.protocolContributorsFeeAda > 0
-            ? `${vault.protocolContributorsFeeAda?.toFixed(2)} ADA Protocol fees + ~1.72 ADA Network fees`
-            : '~1.72 ADA Network fees'}
-          )
+          {selectedNFTs.length > 0 ? (
+            <>
+              Transaction cost:{' '}
+              <span className="text-white font-medium">~{transactionCostEstimate.totalWalletAda.toFixed(2)} ADA</span> (
+              {totalProtocolFeeAda > 0
+                ? `${totalProtocolFeeAda.toFixed(2)} ADA Protocol fees (${feeAssetCount} asset${feeAssetCount !== 1 ? 's' : ''} × ${feePerAssetAda} ADA) + ~${transactionCostEstimate.cardanoOverheadAda.toFixed(2)} ADA Cardano costs`
+                : `~${transactionCostEstimate.cardanoOverheadAda.toFixed(2)} ADA Cardano costs`}
+              )
+            </>
+          ) : (
+            <>Select assets to see estimated transaction cost.</>
+          )}
         </div>
       </div>
     );
@@ -405,13 +425,6 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
                   : 'Total estimated value of your selected assets. Final value is calculated at the end of the contribution window.'
               }
             />
-            {isExpansionMode && vault.protocolContributorsFeeAda > 0 && (
-              <MetricCard
-                label="Protocol Fee"
-                value={`${currencySymbol}${isAda ? vault.protocolContributorsFeeAda.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : vault.protocolContributorsFeeUsd.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`}
-                hint="Fee retained by the protocol for this contribution."
-              />
-            )}
             {!isExpansionMode && (
               <MetricCard
                 label="Vault Allocation"

--- a/src/utils/contributionTransactionCost.js
+++ b/src/utils/contributionTransactionCost.js
@@ -1,0 +1,29 @@
+/**
+ * Estimates ADA wallet cost for a contribution transaction.
+ * Protocol fee scales per asset; Cardano overhead (min ADA + network fee) is
+ * mostly flat when assets are bundled in one output.
+ */
+
+const CARDANO_OVERHEAD_BASE = 3.65;
+const CARDANO_OVERHEAD_PER_EXTRA_ASSET = 0.05;
+
+/**
+ * @param {{ assetCount: number, protocolFeePerAssetAda?: number }} params
+ */
+export function estimateContributionTransactionCost({ assetCount, protocolFeePerAssetAda = 0 }) {
+  const count = Math.max(0, Number.isFinite(assetCount) ? assetCount : 0);
+  const feePerAsset = Number.isFinite(protocolFeePerAssetAda) ? protocolFeePerAssetAda : 0;
+
+  const protocolFeeAda = count * feePerAsset;
+  const cardanoOverheadAda =
+    count > 0 ? CARDANO_OVERHEAD_BASE + Math.max(0, count - 1) * CARDANO_OVERHEAD_PER_EXTRA_ASSET : 0;
+  const totalWalletAda = protocolFeeAda + cardanoOverheadAda;
+
+  return {
+    assetCount: count,
+    protocolFeePerAssetAda: feePerAsset,
+    protocolFeeAda,
+    cardanoOverheadAda,
+    totalWalletAda,
+  };
+}


### PR DESCRIPTION
This pull request improves how contribution transaction costs are estimated and displayed in the UI, making the calculation more accurate and dynamic based on user-selected assets. It introduces a new utility function to estimate costs, updates the display logic in the `ContributeModal`, and removes outdated fee displays.

**Transaction Cost Estimation Improvements:**

* Added `estimateContributionTransactionCost` utility to `src/utils/contributionTransactionCost.js`, which estimates wallet ADA cost based on the number of selected assets and protocol fee per asset. The Cardano overhead is now modeled as a mostly flat base with a small per-asset increment.
* Updated `ContributeModal.jsx` to use the new utility, dynamically calculating protocol and Cardano network fees based on selected assets. Transaction cost display now shows a breakdown and handles the case where no assets are selected. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cR17) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cR178-R201) [[3]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cR361-R375)

**UI and Fee Display Updates:**

* Removed the old static protocol fee display in `ContributeModal.jsx` and replaced it with the new dynamic estimation. The protocol fee metric card for expansion mode was also removed.
* Updated the transaction cost display in `AcquireModal.jsx` to use `protocolAcquiresFeeAda` instead of the outdated `protocolContributorsFeeAda` property.