### PR TITLE
Add weekly interval option to IntervalSelector component

### DIFF
--- a/src/components/shared/IntervalSelector.jsx
+++ b/src/components/shared/IntervalSelector.jsx
@@ -3,6 +3,7 @@ import clsx from 'clsx';
 const INTERVALS = [
   { value: '1h', label: '1H' },
   { value: '1d', label: '1D' },
+  { value: '1w', label: '1W' },
 ];
 
 export const IntervalSelector = ({ activeInterval, onIntervalChange, className = '' }) => {


### PR DESCRIPTION
This pull request adds a new interval option to the `IntervalSelector` component.

- Feature addition:
  * Added a `'1w'` (1 week) interval to the `INTERVALS` array in `IntervalSelector`, allowing users to select a weekly interval.