### PR TITLE
Feature/add chain label

### DIFF
--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -5,7 +5,7 @@ import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
 import { GoldenVerifiedBadge, OFFICIAL_PARTNER_BADGE_HINT } from '@/components/shared/GoldenVerifiedBadge';
 import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 import { formatCompactNumber, formatString, formatVaultStatus } from '@/utils/core.utils';
-import { VaultShortResponse } from '@/utils/types';
+import { ChainTypeLabels, VaultShortResponse } from '@/utils/types';
 import { useCurrency } from '@/hooks/useCurrency';
 import L4vaIcon from '@/icons/l4va.svg?react';
 
@@ -49,6 +49,11 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
             <div className="h-full w-full bg-steel-850 flex items-center justify-center">
               <L4vaIcon className="h-8 w-8 text-white" />
             </div>
+          )}
+          {vault.chainType && (
+            <span className="absolute top-3 right-3 rounded-full bg-black/60 px-3 py-1 text-xs font-medium text-white backdrop-blur-sm">
+              {ChainTypeLabels[vault.chainType] ?? vault.chainType}
+            </span>
           )}
           {shouldShowCountdown && (
             <div className="absolute bottom-0 left-0 w-3/4">

--- a/src/components/vaults/VaultListItem.tsx
+++ b/src/components/vaults/VaultListItem.tsx
@@ -5,7 +5,7 @@ import { VaultCountdown } from '@/components/vault-profile/VaultCountdown';
 import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 import { InfoRow } from '@/components/ui/infoRow';
 import { formatCompactNumber, formatVaultStatus } from '@/utils/core.utils';
-import { VaultShortResponse } from '@/utils/types';
+import { ChainTypeLabels, VaultShortResponse } from '@/utils/types';
 import L4vaIcon from '@/icons/l4va.svg?react';
 
 type VaultListItemProps = {
@@ -52,7 +52,14 @@ const VaultListItem = ({ vault }: VaultListItemProps) => {
         <div className="flex md:ml-[120px] items-center justify-between gap-4 mb-3">
           <div className="flex items-center gap-4">
             <div>
-              <h3 className="font-bold text-xl">{name || 'No name'}</h3>
+              <div className="flex items-center gap-2">
+                <h3 className="font-bold text-xl">{name || 'No name'}</h3>
+                {vault.chainType && (
+                  <span className="rounded-full bg-steel-850 px-3 py-0.5 text-xs font-medium text-white">
+                    {ChainTypeLabels[vault.chainType] ?? vault.chainType}
+                  </span>
+                )}
+              </div>
               <p className="text-sm text-dark-100">{description || 'No description'}</p>
             </div>
           </div>

--- a/src/components/vaults/steps/Launch/index.jsx
+++ b/src/components/vaults/steps/Launch/index.jsx
@@ -3,9 +3,13 @@ import { LaunchAssetContribution } from '@/components/vaults/steps/Launch/Launch
 import { LaunchAcquireWindow } from '@/components/vaults/steps/Launch/LaunchAcquireWindow';
 import { LaunchGovernance } from '@/components/vaults/steps/Launch/LaunchGovernance';
 import { useVlrmFeeSettings } from '@/services/api/queries';
+import { useNetwork } from '@/hooks/useNetwork';
+import { ChainType, ChainTypeLabels } from '@/utils/types';
 
 export const Launch = ({ data, setCurrentStep }) => {
   const { data: vlrmFeeData, isLoading: isVlrmFeeLoading } = useVlrmFeeSettings();
+  const { network } = useNetwork();
+  const networkLabel = ChainTypeLabels[network] ?? ChainTypeLabels[ChainType.CARDANO];
 
   const vlrmFeeSettings = vlrmFeeData?.data || {
     vlrm_creator_fee: 1000,
@@ -20,6 +24,13 @@ export const Launch = ({ data, setCurrentStep }) => {
       <LaunchAssetContribution data={data} setCurrentStep={setCurrentStep} />
       <LaunchAcquireWindow data={data} setCurrentStep={setCurrentStep} />
       <LaunchGovernance data={data} setCurrentStep={setCurrentStep} />
+      <div className="bg-steel-900/50 border border-steel-800/50 rounded-lg p-4 md:p-6 flex items-center justify-between gap-4">
+        <p className="text-base font-medium text-white">This vault will be created on:</p>
+        <span className="flex items-center gap-2 text-base font-medium text-white">
+          <span className="w-2 h-2 rounded-full bg-orange-500" />
+          {networkLabel}
+        </span>
+      </div>
       <div className="bg-steel-900/50 border border-steel-800/50 rounded-lg p-4 md:p-6">
         <p className="text-sm text-dark-100 mb-2">Transaction Costs:</p>
         <p className="text-base font-medium">

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -75,6 +75,16 @@ export enum ClaimStatus {
   CLAIMED = 'claimed',
 }
 
+export enum ChainType {
+  CARDANO = 'cardano',
+  ROBINHOOD = 'robinhood',
+}
+
+export const ChainTypeLabels: Record<ChainType, string> = {
+  [ChainType.CARDANO]: 'Cardano',
+  [ChainType.ROBINHOOD]: 'Robinhood',
+};
+
 // Type interfaces based on @Expose annotations
 export interface IUser {
   id: string;
@@ -209,6 +219,7 @@ export interface VaultShortResponse {
   ftTokenImg?: string;
   vaultTokenTicker?: string;
   isOfficialPartner?: boolean;
+  chainType?: ChainType;
 }
 
 export interface PaginatedResponse<T> {


### PR DESCRIPTION
This pull request introduces support for displaying the vault's blockchain network (chain type) across the UI. It adds the `ChainType` enum and corresponding labels, updates the data model to include `chainType`, and ensures that both the vault card and list item components display the chain label when available. Additionally, during the vault creation process, the selected network is now shown to the user.

**Chain type support and display:**

* Added `ChainType` enum and `ChainTypeLabels` mapping to `src/utils/types.ts` for standardized chain identification and display names.
* Updated `VaultShortResponse` interface to optionally include a `chainType` property.

**UI enhancements for chain type:**

* Modified `VaultCard` and `VaultListItem` components to display the chain type label (e.g., "Cardano", "Robinhood") as a badge if `chainType` is present in the vault data. [[1]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffR53-R57) [[2]](diffhunk://#diff-b92262fc2dd71d1ce22a89717a04009ca3d20f1fceacdfb30be5b7b83fe7a416R55-R62)
* Updated imports in relevant files to use the new `ChainTypeLabels` and `ChainType` definitions. [[1]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffL8-R8) [[2]](diffhunk://#diff-b92262fc2dd71d1ce22a89717a04009ca3d20f1fceacdfb30be5b7b83fe7a416L8-R8)

**Vault creation flow:**

* In the vault launch stepper (`src/components/vaults/steps/Launch/index.jsx`), added a section showing the network on which the vault will be created, using the current network from `useNetwork` and the chain label mapping. [[1]](diffhunk://#diff-7119eef0f3e7f38bd049c5301a382afb8dc385f0592c6f6ce96735c74ba326b7R6-R12) [[2]](diffhunk://#diff-7119eef0f3e7f38bd049c5301a382afb8dc385f0592c6f6ce96735c74ba326b7R27-R33)

These changes ensure that users are informed about the blockchain network associated with each vault throughout the app.