### PR TITLE
add eth price

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -47,6 +47,7 @@ export const Header = () => {
   const currencyOptions = [
     { label: 'ADA', value: 'ada' },
     { label: 'USD', value: 'usdt' },
+    { label: 'ETH', value: 'eth' },
   ];
 
   const networkOptions = [

--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -1,10 +1,9 @@
 import { useCountAnimation } from '@/hooks/useCountAnimation';
 import { useStatistics } from '@/services/api/queries';
 import { useCurrency } from '@/hooks/useCurrency';
-import { formatNum } from '@/utils/core.utils.js';
 
-const Counter = ({ value, prefix = '' }) => {
-  const animatedValue = useCountAnimation(value);
+const Counter = ({ value, prefix = '', decimals = 0 }) => {
+  const animatedValue = useCountAnimation(value, 2000, decimals);
   return (
     <span>
       {prefix}
@@ -16,12 +15,14 @@ const Counter = ({ value, prefix = '' }) => {
 const HeroStats = () => {
   const { data } = useStatistics();
   const stats = data?.data;
-  const { currency, currencySymbol } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
-  const formatCurrencyValue = (adaValue, usdValue) => {
-    const value = currency === 'ada' ? adaValue : usdValue;
-    return formatNum(value || 0);
+  const formatCurrencyValue = (adaValue, usdValue, ethValue) => {
+    return pickByCurrency({ ada: adaValue, usd: usdValue, eth: ethValue }) || 0;
   };
+
+  // Only ETH prices need fractional precision; ADA/USD stay whole numbers as before.
+  const currencyDecimals = pickByCurrency({ ada: 0, usd: 0, eth: 4 });
 
   return (
     <div className="flex flex-col md:flex-row gap-8">
@@ -37,7 +38,11 @@ const HeroStats = () => {
         <div className="text-center md:text-left">
           <p>TVL</p>
           <p className="text-orange-500 text-2xl sm:text-4xl">
-            <Counter value={formatCurrencyValue(stats?.totalValueAda, stats?.totalValueUsd)} prefix={currencySymbol} />
+            <Counter
+              value={formatCurrencyValue(stats?.totalValueAda, stats?.totalValueUsd, stats?.totalValueEth)}
+              prefix={currencySymbol}
+              decimals={currencyDecimals}
+            />
           </p>
         </div>
       </div>
@@ -46,8 +51,13 @@ const HeroStats = () => {
           <p>Total Contributed</p>
           <p className="text-orange-500 text-2xl sm:text-4xl">
             <Counter
-              value={formatCurrencyValue(stats?.totalContributedAda, stats?.totalContributedUsd)}
+              value={formatCurrencyValue(
+                stats?.totalContributedAda,
+                stats?.totalContributedUsd,
+                stats?.totalContributedEth
+              )}
               prefix={currencySymbol}
+              decimals={currencyDecimals}
             />
           </p>
         </div>

--- a/src/components/modals/AcquireModal.jsx
+++ b/src/components/modals/AcquireModal.jsx
@@ -13,7 +13,7 @@ import { Spinner } from '@/components/Spinner';
 
 export const AcquireModal = ({ vault, onClose }) => {
   const { name, tokensForAcquires, liquidityPoolContribution, ftTokenSupply } = vault;
-  const { currency, currencySymbol } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
   const [acquireAmount, setAcquireAmount] = useState(0);
   const { mutateAsync: createAcquireTx } = useCreateAcquireTx();
   const wallet = useWallet('handler', 'isConnected', 'balanceAda', 'balanceDecoded', 'isUpdatingUtxos');
@@ -235,7 +235,11 @@ export const AcquireModal = ({ vault, onClose }) => {
                 <p className="text-xl font-medium">
                   {currencySymbol}
                   {formatNum(
-                    currency === 'ada' ? vault.assetsPrices.totalAcquiredAda : vault.assetsPrices.totalAcquiredUsd
+                    pickByCurrency({
+                      ada: vault.assetsPrices.totalAcquiredAda,
+                      usd: vault.assetsPrices.totalAcquiredUsd,
+                      eth: vault.assetsPrices.totalAcquiredEth,
+                    })
                   )}
                 </p>
               </div>

--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -22,7 +22,7 @@ const MAX_FT_PER_TRANSACTION = 10;
 const MAX_SAFE_QUANTITY = Number.MAX_SAFE_INTEGER; // 9,007,199,254,740,991
 
 export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
-  const { currencySymbol, isAda } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
   const { name, recipientAddress, assetsWhitelist } = vault;
   const [selectedNFTs, setSelectedNFTs] = useState([]);
   const [activeTab, setActiveTab] = useState('NFT');
@@ -90,15 +90,32 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
         // asset.priceAda is per decimal-adjusted unit
         // So we can directly multiply: decimalAmount * pricePerDecimalUnit
         const selectedDecimalQty = Number(asset.amount) || 0;
-        const pricePerDecimalUnit = isAda ? asset.priceAda : asset.priceUsd;
+        const pricePerDecimalUnit = pickByCurrency({ ada: asset.priceAda, usd: asset.priceUsd, eth: asset.priceEth });
         total += selectedDecimalQty * pricePerDecimalUnit;
       } else {
         // For NFTs, use full value
-        total += isAda ? asset.valueAda : asset.valueUsd;
+        total += pickByCurrency({ ada: asset.valueAda, usd: asset.valueUsd, eth: asset.valueEth });
       }
     });
     return total;
-  }, [selectedNFTs, isAda]);
+  }, [selectedNFTs, pickByCurrency]);
+
+  // Same sum always expressed in ADA - VT math below is denominated in ADA regardless of the
+  // display currency, and the ADA<->display rate is derived from this pair (no separate rate field).
+  const estimatedValueAda = useMemo(() => {
+    let total = 0;
+    selectedNFTs.forEach(asset => {
+      if (asset.isFungibleToken) {
+        total += (Number(asset.amount) || 0) * asset.priceAda;
+      } else {
+        total += asset.valueAda;
+      }
+    });
+    return total;
+  }, [selectedNFTs]);
+
+  // Units of the active display currency per 1 ADA (1 when the display currency is ADA).
+  const displayPerAda = estimatedValueAda > 0 ? estimatedValue / estimatedValueAda : 1;
 
   // Vault Allocation Formula: (1 - tokens for acq %) × (1 - ((LP % Contribution)/2))
   const tokensForAcqPercent = vault.tokensForAcquires / 100;
@@ -112,7 +129,7 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
   const expansionVTAmount = useMemo(() => {
     if (!isExpansionMode || !hasSelectedAssets) return 0;
 
-    const assetValueAda = isAda ? estimatedValue : estimatedValue / (vault.adaPrice || 1);
+    const assetValueAda = estimatedValueAda;
     const decimals = vault.ftTokenDecimals ?? 6;
     const decimalMultiplier = Math.pow(10, decimals);
 
@@ -136,7 +153,7 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
       if (!currentVtPrice || currentVtPrice === 0) return 0;
       return (assetValueAda / currentVtPrice) * decimalMultiplier;
     }
-  }, [isExpansionMode, hasSelectedAssets, selectedNFTs, isAda, estimatedValue, vault]);
+  }, [isExpansionMode, hasSelectedAssets, selectedNFTs, estimatedValueAda, vault]);
 
   const expansionVTValue = useMemo(() => {
     if (!isExpansionMode || !hasSelectedAssets) return 0;
@@ -144,10 +161,14 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     const decimals = vault.ftTokenDecimals ?? 6;
     const decimalMultiplier = Math.pow(10, decimals);
     const vtCount = expansionVTAmount / decimalMultiplier;
-    const vtPriceInCurrency = isAda ? vault.vtPrice : vault.vtPrice * (vault.adaPrice || 1);
+    const vtPriceInCurrency = pickByCurrency({
+      ada: vault.vtPrice,
+      usd: vault.vtPrice * (vault.adaPrice || 1),
+      eth: vault.vtPrice * displayPerAda,
+    });
 
     return vtCount * vtPriceInCurrency;
-  }, [isExpansionMode, hasSelectedAssets, expansionVTAmount, isAda, vault]);
+  }, [isExpansionMode, hasSelectedAssets, expansionVTAmount, pickByCurrency, displayPerAda, vault]);
 
   const expansionValueDifference = useMemo(() => {
     if (!isExpansionMode || !hasSelectedAssets || estimatedValue === 0) return 0;
@@ -155,9 +176,11 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
   }, [isExpansionMode, hasSelectedAssets, expansionVTValue, estimatedValue]);
 
   // Get current vault TVL (what contributors have already contributed)
-  const currentVaultTVL = isAda
-    ? vault.assetsPrices?.totalValueAda || vault.totalAssetsCostAda || 0
-    : vault.assetsPrices?.totalValueUsd || vault.totalAssetsCostUsd || 0;
+  const currentVaultTVL = pickByCurrency({
+    ada: vault.assetsPrices?.totalValueAda || vault.totalAssetsCostAda || 0,
+    usd: vault.assetsPrices?.totalValueUsd || vault.totalAssetsCostUsd || 0,
+    eth: vault.assetsPrices?.totalValueEth || vault.totalAssetsCostEth || 0,
+  });
 
   // Calculate user's share of the total contributor pool
   const totalContributorValue = currentVaultTVL + estimatedValue;
@@ -200,7 +223,11 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     hasSelectedAssets && hasAcquirePhase
       ? ((tokensForAcqPercent - lpContributionPercent / 2) * estimatedValue).toFixed(2).toLocaleString()
       : '0.00';
-  const estimatedReceivedLabel = isAda ? 'Estimated ADA Received' : 'Estimated USD Received';
+  const estimatedReceivedLabel = pickByCurrency({
+    ada: 'Estimated ADA Received',
+    usd: 'Estimated USD Received',
+    eth: 'Estimated ETH Received',
+  });
 
   const toggleNFT = useCallback(asset => {
     if (asset.isFungibleToken) return;

--- a/src/components/shared/VaultMetrics.jsx
+++ b/src/components/shared/VaultMetrics.jsx
@@ -28,7 +28,7 @@ const MetricsSkeleton = () => (
 );
 
 const VaultMetrics = ({ marketData, isLoading }) => {
-  const { currency, currencySymbol } = useCurrency();
+  const { currency, currencySymbol, pickByCurrency } = useCurrency();
 
   if (isLoading) {
     return <MetricsSkeleton />;
@@ -48,11 +48,18 @@ const VaultMetrics = ({ marketData, isLoading }) => {
   const adaPrice = marketData.adaPrice != null ? Number(marketData.adaPrice) : null;
   const totalVolumeUsd =
     totalVolumeAda != null && adaPrice != null && !Number.isNaN(adaPrice) ? totalVolumeAda * adaPrice : null;
+  const adaEthPrice = marketData.adaEthPrice != null ? Number(marketData.adaEthPrice) : null;
+  const totalVolumeEth =
+    totalVolumeAda != null && adaEthPrice != null && !Number.isNaN(adaEthPrice) ? totalVolumeAda * adaEthPrice : null;
 
-  const priceValue = currency === 'ada' ? marketData.price_ada : marketData.price_usd;
-  const tvlValue = currency === 'ada' ? marketData.tvl_ada : marketData.tvl_usd;
-  const fdvValue = currency === 'ada' ? marketData.fdv_ada : marketData.fdv_usd;
-  const totalVolumeValue = currency === 'ada' ? totalVolumeAda : totalVolumeUsd;
+  const priceValue = pickByCurrency({
+    ada: marketData.price_ada,
+    usd: marketData.price_usd,
+    eth: marketData.price_eth,
+  });
+  const tvlValue = pickByCurrency({ ada: marketData.tvl_ada, usd: marketData.tvl_usd, eth: marketData.tvl_eth });
+  const fdvValue = pickByCurrency({ ada: marketData.fdv_ada, usd: marketData.fdv_usd, eth: marketData.fdv_eth });
+  const totalVolumeValue = pickByCurrency({ ada: totalVolumeAda, usd: totalVolumeUsd, eth: totalVolumeEth });
 
   const fdvTvl = marketData.fdv_tvl != null && marketData.fdv_tvl !== '' ? Number(marketData.fdv_tvl).toFixed(2) : null;
 
@@ -61,7 +68,7 @@ const VaultMetrics = ({ marketData, isLoading }) => {
       <div className="grid grid-cols-2 gap-3">
         <MetricCard
           label="Price"
-          value={currency === 'ada' ? `${currencySymbol}${formatAdaPrice(priceValue)}` : formatUsdCurrency(priceValue)}
+          value={currency === 'usdt' ? formatUsdCurrency(priceValue) : `${currencySymbol}${formatAdaPrice(priceValue)}`}
         />
         <MetricCard label="Market Cap" value={formatLargeNumber(marketData.mcap)} />
       </div>

--- a/src/components/vault-profile/VaultAcquiredAssetsList.jsx
+++ b/src/components/vault-profile/VaultAcquiredAssetsList.jsx
@@ -24,7 +24,7 @@ const StatBadge = ({ icon: Icon, label, value }) => (
 
 export const VaultAcquiredAssetsList = ({ vault }) => {
   const [expandedAsset, setExpandedAsset] = useState(null);
-  const { currencySymbol, isAda, currency } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
   const limit = 10;
 
   const [appliedFilters, setAppliedFilters] = useState({
@@ -83,7 +83,13 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
             <div className="flex items-baseline gap-1 text-white">
               <span className="text-3xl md:text-2xl font-bold tracking-tight">
                 {currencySymbol}
-                {formatLargeNumber(isAda ? data?.data?.totalAcquired || 0 : data?.data?.totalAcquiredUsd || 0)}
+                {formatLargeNumber(
+                  pickByCurrency({
+                    ada: data?.data?.totalAcquired || 0,
+                    usd: data?.data?.totalAcquiredUsd || 0,
+                    eth: data?.data?.totalAcquiredEth || 0,
+                  })
+                )}
               </span>
             </div>
           </div>
@@ -96,13 +102,22 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
               value={
                 vault.vaultStatus === 'locked'
                   ? (() => {
-                      const val = isAda ? data?.data?.totalAdaLiquidityAda : data?.data?.totalAdaLiquidityUsd;
-                      return val != null ? (isAda ? `₳${formatNum(2 * val)}` : `$${formatNum(2 * val)}`) : 'N/A';
+                      const val = pickByCurrency({
+                        ada: data?.data?.totalAdaLiquidityAda,
+                        usd: data?.data?.totalAdaLiquidityUsd,
+                        eth: data?.data?.totalAdaLiquidityEth,
+                      });
+                      return val != null ? `${currencySymbol}${formatNum(2 * val)}` : 'N/A';
                     })()
                   : vault.projectedLpAdaAmount || vault.projectedLpUsdAmount
-                    ? currency === 'ada'
-                      ? `₳${formatNum(2 * vault.projectedLpAdaAmount)}`
-                      : `$${formatNum(2 * vault.projectedLpUsdAmount)}`
+                    ? `${currencySymbol}${formatNum(
+                        2 *
+                          pickByCurrency({
+                            ada: vault.projectedLpAdaAmount,
+                            usd: vault.projectedLpUsdAmount,
+                            eth: vault.projectedLpEthAmount,
+                          })
+                      )}`
                     : 'N/A'
               }
             />

--- a/src/components/vault-profile/VaultContributedAssetsCard.jsx
+++ b/src/components/vault-profile/VaultContributedAssetsCard.jsx
@@ -4,7 +4,7 @@ import { useState } from 'react';
 
 import { substringAddress, formatAdaPrice, formatNum } from '@/utils/core.utils.js';
 
-const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda }) => {
+const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, pickByCurrency }) => {
   const handleCopy = (e, text, message) => {
     e.stopPropagation();
     navigator.clipboard.writeText(text);
@@ -66,7 +66,9 @@ const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda }) => {
               <p className="font-medium text-gray-300">Value:</p>
               <p>
                 {currencySymbol}
-                {formatAdaPrice(isAda ? asset.valueAda || 0 : asset.valueUsd || 0)}
+                {formatAdaPrice(
+                  pickByCurrency({ ada: asset.valueAda || 0, usd: asset.valueUsd || 0, eth: asset.valueEth || 0 })
+                )}
               </p>
             </div>
             <div>
@@ -117,7 +119,7 @@ const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda }) => {
   );
 };
 
-export const VaultContributedAssetsCard = ({ assets, currencySymbol, isAda }) => {
+export const VaultContributedAssetsCard = ({ assets, currencySymbol, pickByCurrency }) => {
   const [expandedAsset, setExpandedAsset] = useState(null);
 
   return (
@@ -129,7 +131,7 @@ export const VaultContributedAssetsCard = ({ assets, currencySymbol, isAda }) =>
           isExpanded={expandedAsset === index}
           onClick={() => setExpandedAsset(expandedAsset === index ? null : index)}
           currencySymbol={currencySymbol}
-          isAda={isAda}
+          pickByCurrency={pickByCurrency}
         />
       ))}
     </div>

--- a/src/components/vault-profile/VaultContributedAssetsList.jsx
+++ b/src/components/vault-profile/VaultContributedAssetsList.jsx
@@ -26,7 +26,7 @@ const StatBadge = ({ icon: Icon, label, value }) => (
 
 const VaultContributedAssetsList = ({ vault }) => {
   const [expandedAsset, setExpandedAsset] = useState(null);
-  const { currencySymbol, isAda } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
   const limit = 10;
 
   const [appliedFilters, setAppliedFilters] = useState({
@@ -101,7 +101,13 @@ const VaultContributedAssetsList = ({ vault }) => {
             <div className="flex items-baseline gap-1 text-white">
               <span className="text-3xl md:text-2xl font-bold tracking-tight">
                 {currencySymbol}
-                {formatLargeNumber(isAda ? statistics?.totalAssetValueAda || 0 : statistics?.totalAssetValueUsd || 0)}
+                {formatLargeNumber(
+                  pickByCurrency({
+                    ada: statistics?.totalAssetValueAda || 0,
+                    usd: statistics?.totalAssetValueUsd || 0,
+                    eth: statistics?.totalAssetValueEth || 0,
+                  })
+                )}
               </span>
             </div>
           </div>
@@ -113,7 +119,11 @@ const VaultContributedAssetsList = ({ vault }) => {
               icon={Layers}
               label="Assets Avg"
               value={`${currencySymbol}${formatLargeNumber(
-                isAda ? statistics?.assetsAvgAda || 0 : statistics?.assetsAvgUsd || 0
+                pickByCurrency({
+                  ada: statistics?.assetsAvgAda || 0,
+                  usd: statistics?.assetsAvgUsd || 0,
+                  eth: statistics?.assetsAvgEth || 0,
+                })
               )}`}
             />
           </div>
@@ -176,7 +186,7 @@ const VaultContributedAssetsList = ({ vault }) => {
         </div>
       ) : (
         <>
-          <VaultContributedAssetsCard assets={assets} currencySymbol={currencySymbol} isAda={isAda} />
+          <VaultContributedAssetsCard assets={assets} currencySymbol={currencySymbol} pickByCurrency={pickByCurrency} />
           <div className="md:block overflow-x-auto rounded-2xl border border-steel-750 hidden">
             <table className="w-full">
               <thead>
@@ -228,7 +238,13 @@ const VaultContributedAssetsList = ({ vault }) => {
                         <td className="px-4 py-3">{formatNum(asset.quantity, 6)}</td>
                         <td className="px-4 py-3">
                           {currencySymbol}
-                          {formatAdaPrice(isAda ? asset.valueAda || 0 : asset.valueUsd || 0)}
+                          {formatAdaPrice(
+                            pickByCurrency({
+                              ada: asset.valueAda || 0,
+                              usd: asset.valueUsd || 0,
+                              eth: asset.valueEth || 0,
+                            })
+                          )}
                         </td>
                         <td className="px-4 py-3 text-center">
                           <button

--- a/src/components/vault-profile/VaultContribution.jsx
+++ b/src/components/vault-profile/VaultContribution.jsx
@@ -55,12 +55,14 @@ const ProgressBubble = ({ value, progress }) => {
   );
 };
 
-const AcquireExpansionProgress = ({ vault, currency }) => {
+const AcquireExpansionProgress = ({ vault, currencySymbol, pickByCurrency }) => {
   const hasMax = !vault.acquireExpansionNoMax && vault.acquireExpansionMaxAda > 0;
   const currentAda = vault.acquireExpansionCurrentAda || 0;
   const currentUsd = vault.acquireExpansionCurrentUsd || 0;
+  const currentEth = vault.acquireExpansionCurrentEth || 0;
   const maxAda = vault.acquireExpansionMaxAda || 0;
   const maxUsd = vault.acquireExpansionMaxUsd || 0;
+  const maxEth = vault.acquireExpansionMaxEth || 0;
 
   const progress = hasMax ? calculateProgress(currentAda, maxAda) : 0;
 
@@ -71,7 +73,8 @@ const AcquireExpansionProgress = ({ vault, currency }) => {
         <>
           <div className="flex justify-between text-sm mb-1">
             <span className="text-dark-100">
-              Raised: {currency === 'ada' ? `₳${formatNum(currentAda)}` : `$${formatNum(currentUsd)}`}
+              Raised:{' '}
+              {`${currencySymbol}${formatNum(pickByCurrency({ ada: currentAda, usd: currentUsd, eth: currentEth }))}`}
             </span>
             <span className="text-dark-100">{Math.floor(progress)}%</span>
           </div>
@@ -88,7 +91,9 @@ const AcquireExpansionProgress = ({ vault, currency }) => {
           </div>
           <div className="flex justify-between w-full text-xs text-dark-100">
             <span>min 0 ADA</span>
-            <span>max {currency === 'ada' ? `₳${formatNum(maxAda)}` : `$${formatNum(maxUsd)}`}</span>
+            <span>
+              max {`${currencySymbol}${formatNum(pickByCurrency({ ada: maxAda, usd: maxUsd, eth: maxEth }))}`}
+            </span>
           </div>
         </>
       ) : (
@@ -96,7 +101,7 @@ const AcquireExpansionProgress = ({ vault, currency }) => {
           <div className="flex w-full justify-start gap-1 text-sm text-dark-100 mb-2">
             Total Raised:{' '}
             <span className="text-white font-medium">
-              {currency === 'ada' ? `₳${formatNum(currentAda)}` : `$${formatNum(currentUsd)}`}
+              {`${currencySymbol}${formatNum(pickByCurrency({ ada: currentAda, usd: currentUsd, eth: currentEth }))}`}
             </span>
           </div>
           <div className="text-sm text-dark-100 mb-2">
@@ -219,7 +224,7 @@ const ContributionProgress = ({
 
 export const VaultContribution = ({ vault }) => {
   const [showMoreInfo, setShowMoreInfo] = useState(false);
-  const { currency } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
   const isContribution = vault.vaultStatus === VAULT_STATUSES.CONTRIBUTION;
   const isAcquire = vault.vaultStatus === VAULT_STATUSES.ACQUIRE;
@@ -271,9 +276,13 @@ export const VaultContribution = ({ vault }) => {
               <div className="flex justify-between text-sm mb-1">
                 <span className="text-dark-100">
                   Reserve:{' '}
-                  {currency === 'ada'
-                    ? `₳${formatNum(vault.requireReservedCostAda)}`
-                    : `$${formatNum(vault.requireReservedCostUsd)}`}
+                  {`${currencySymbol}${formatNum(
+                    pickByCurrency({
+                      ada: vault.requireReservedCostAda,
+                      usd: vault.requireReservedCostUsd,
+                      eth: vault.requireReservedCostEth,
+                    })
+                  )}`}
                 </span>
                 <span className="text-dark-100">{Math.floor(acquireProgress)}%</span>
               </div>
@@ -312,9 +321,13 @@ export const VaultContribution = ({ vault }) => {
                       <div className="flex justify-between">
                         <span className="text-dark-100">Current ADA LP amount:</span>
                         <span className="text-dark-100">
-                          {currency === 'ada'
-                            ? `₳${formatNum(vault.projectedLpAdaAmount)}`
-                            : `$${formatNum(vault.projectedLpUsdAmount)}`}
+                          {`${currencySymbol}${formatNum(
+                            pickByCurrency({
+                              ada: vault.projectedLpAdaAmount,
+                              usd: vault.projectedLpUsdAmount,
+                              eth: vault.projectedLpEthAmount,
+                            })
+                          )}`}
                         </span>
                       </div>
                       <div className="flex justify-between">
@@ -363,9 +376,13 @@ export const VaultContribution = ({ vault }) => {
                           <div className="flex justify-between">
                             <span className="text-dark-100">Current ADA LP amount:</span>
                             <span className="text-dark-100">
-                              {currency === 'ada'
-                                ? `₳${formatNum(vault.projectedLpAdaAmount)}`
-                                : `$${formatNum(vault.projectedLpUsdAmount)}`}
+                              {`${currencySymbol}${formatNum(
+                                pickByCurrency({
+                                  ada: vault.projectedLpAdaAmount,
+                                  usd: vault.projectedLpUsdAmount,
+                                  eth: vault.projectedLpEthAmount,
+                                })
+                              )}`}
                             </span>
                           </div>
                           <div className="flex justify-between">
@@ -399,9 +416,13 @@ export const VaultContribution = ({ vault }) => {
             <div className="text-sm text-dark-100 font-medium">
               Total Acquired Amount:{' '}
               <span className="text-[#F97316]">
-                {currency === 'ada'
-                  ? `₳${formatNumber(vault.assetsPrices.totalAcquiredAda || 0)}`
-                  : `$${formatNumber(vault.assetsPrices.totalAcquiredUsd || 0)}`}
+                {`${currencySymbol}${formatNumber(
+                  pickByCurrency({
+                    ada: vault.assetsPrices.totalAcquiredAda || 0,
+                    usd: vault.assetsPrices.totalAcquiredUsd || 0,
+                    eth: vault.assetsPrices.totalAcquiredEth || 0,
+                  })
+                )}`}
               </span>
             </div>
           </div>
@@ -422,7 +443,7 @@ export const VaultContribution = ({ vault }) => {
             setShowMoreInfo={setShowMoreInfo}
           />
         ) : isAcquireExpansion ? (
-          <AcquireExpansionProgress vault={vault} currency={currency} />
+          <AcquireExpansionProgress vault={vault} currencySymbol={currencySymbol} pickByCurrency={pickByCurrency} />
         ) : null}
       </div>
 

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -184,7 +184,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
 
   const { isAuthenticated, user } = useAuth();
   const { openModal } = useModalControls();
-  const { isAda, currencySymbol } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
   const [activeTab, setActiveTab] = useState(initialTab || 'Assets');
   const [deferredReady, setDeferredReady] = useState(false);
@@ -389,12 +389,20 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
   const vaultStats = {
     assetValue: vault.vaultStatus,
     ftGains: (() => {
-      const val = isAda ? vault.vaultStats?.ftGainsAda : vault.vaultStats?.ftGainsUsd;
+      const val = pickByCurrency({
+        ada: vault.vaultStats?.ftGainsAda,
+        usd: vault.vaultStats?.ftGainsUsd,
+        eth: vault.vaultStats?.ftGainsEth,
+      });
       if (val == null) return 'N/A';
       return `${val < 0 ? '-' : ''}${currencySymbol}${formatNum(Math.abs(val))}`;
     })(),
     fdv: (() => {
-      const val = isAda ? vault.vaultStats?.fdvAda : vault.vaultStats?.fdvUsd;
+      const val = pickByCurrency({
+        ada: vault.vaultStats?.fdvAda,
+        usd: vault.vaultStats?.fdvUsd,
+        eth: vault.vaultStats?.fdvEth,
+      });
       if (val == null) return 'N/A';
       return `${currencySymbol}${formatNum(val)}`;
     })(),
@@ -405,12 +413,20 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
       return val.toFixed(2);
     })(),
     vtPrice: (() => {
-      const val = isAda ? vault.vaultStats?.vtPriceAda : vault.vaultStats?.vtPriceUsd;
+      const val = pickByCurrency({
+        ada: vault.vaultStats?.vtPriceAda,
+        usd: vault.vaultStats?.vtPriceUsd,
+        eth: vault.vaultStats?.vtPriceEth,
+      });
       if (val == null) return 'N/A';
       return `${currencySymbol}${formatNum(val, 4)}`;
     })(),
     tvl: (() => {
-      const val = isAda ? vault.vaultStats?.tvlAda : vault.vaultStats?.tvlUsd;
+      const val = pickByCurrency({
+        ada: vault.vaultStats?.tvlAda,
+        usd: vault.vaultStats?.tvlUsd,
+        eth: vault.vaultStats?.tvlEth,
+      });
       if (val == null) return 'N/A';
       return `${currencySymbol}${formatNum(val)}`;
     })(),

--- a/src/components/vault-profile/VaultSettings.jsx
+++ b/src/components/vault-profile/VaultSettings.jsx
@@ -30,7 +30,7 @@ export const VaultSettings = ({ vault }) => {
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showCancelConfirmation, setShowCancelConfirmation] = useState(false);
   const [isCancelVaultPending, setIsCancelVaultPending] = useState(false);
-  const { currency } = useCurrency();
+  const { pickByCurrency } = useCurrency();
   const { user } = useAuth();
   const wallet = useWallet('handler', 'isConnected', 'isUpdatingUtxos');
   const navigate = useNavigate();
@@ -209,13 +209,21 @@ export const VaultSettings = ({ vault }) => {
             <InfoRow label="Tokens For Acquirers (%)" symbol="%" value={vault.tokensForAcquires} />
             <InfoRow
               label="Asset Value @ Lock"
-              symbol={currency === 'ada' ? 'ADA' : 'USD'}
-              value={currency === 'ada' ? vault.assetsPrices.totalValueAda : vault.assetsPrices.totalValueUsd}
+              symbol={pickByCurrency({ ada: 'ADA', usd: 'USD', eth: 'ETH' })}
+              value={pickByCurrency({
+                ada: vault.assetsPrices.totalValueAda,
+                usd: vault.assetsPrices.totalValueUsd,
+                eth: vault.assetsPrices.totalValueEth,
+              })}
             />
             <InfoRow
               label="Acquire Amount @ Lock"
-              symbol={currency === 'ada' ? 'ADA' : 'USD'}
-              value={currency === 'ada' ? vault.assetsPrices.totalAcquiredAda : vault.assetsPrices.totalAcquiredUsd}
+              symbol={pickByCurrency({ ada: 'ADA', usd: 'USD', eth: 'ETH' })}
+              value={pickByCurrency({
+                ada: vault.assetsPrices.totalAcquiredAda,
+                usd: vault.assetsPrices.totalAcquiredUsd,
+                eth: vault.assetsPrices.totalAcquiredEth,
+              })}
             />
             <InfoRow
               label="Implied Vault Valuation @ Lock"

--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -17,7 +17,7 @@ const ONE_DAY_MS = 24 * 60 * 60 * 1000;
 
 export const VaultCard = ({ vault }: VaultCardProps) => {
   const { id, name, description, vaultImage, ftTokenImg, socialLinks = [] } = vault;
-  const { currency } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
   const shouldShowCountdown = useMemo(() => {
     if (!vault?.phaseEndTime || !vault?.phaseStartTime) return false;
@@ -90,9 +90,13 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
               <p className="text-sm text-dark-100">TVL</p>
               <p className="font-bold">
                 {vault.totalValueAda && vault.totalValueUsd
-                  ? currency === 'ada'
-                    ? `₳${formatCompactNumber(vault.totalValueAda)}`
-                    : `$${formatCompactNumber(vault.totalValueUsd)}`
+                  ? `${currencySymbol}${formatCompactNumber(
+                      pickByCurrency({
+                        ada: vault.totalValueAda,
+                        usd: vault.totalValueUsd,
+                        eth: vault.totalValueEth ?? 0,
+                      })
+                    )}`
                   : 'N/A'}
               </p>
             </div>

--- a/src/components/vaults/VaultTokensStatistics.jsx
+++ b/src/components/vaults/VaultTokensStatistics.jsx
@@ -23,7 +23,7 @@ const TIME_PERIOD_MAP = {
 
 export const VaultTokensStatistics = () => {
   const { openModal } = useModalControls();
-  const { currency } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
   const [timePeriod, setTimePeriod] = useState('1d');
   const [filters, setFilters] = useState({
     page: 1,
@@ -55,7 +55,7 @@ export const VaultTokensStatistics = () => {
     sortBy: filters.sortBy,
     sortOrder: filters.sortOrder,
     ticker: filters.ticker || undefined,
-    currency: currency === 'ada' ? 'ada' : 'usd',
+    currency: pickByCurrency({ ada: 'ada', usd: 'usd', eth: 'eth' }),
     minPrice: toNum(filters.minPrice),
     maxPrice: toNum(filters.maxPrice),
     minFdv: toNum(filters.minFdv),
@@ -161,7 +161,11 @@ export const VaultTokensStatistics = () => {
         key: 'price',
         header: 'Price',
         sortable: true,
-        render: item => (currency === 'ada' ? `₳${formatNum(item.price_ada, 4)}` : `$${formatNum(item.price_usd, 4)}`),
+        render: item =>
+          `${currencySymbol}${formatNum(
+            pickByCurrency({ ada: item.price_ada, usd: item.price_usd, eth: item.price_eth }),
+            4
+          )}`,
         cellClassName: 'text-white',
       },
       {
@@ -190,7 +194,10 @@ export const VaultTokensStatistics = () => {
         key: 'fdv_per_asset',
         header: 'FDV / Asset',
         sortable: true,
-        render: item => formatLargeNumber(currency === 'ada' ? item.fdv_per_asset_ada : item.fdv_per_asset_usd),
+        render: item =>
+          formatLargeNumber(
+            pickByCurrency({ ada: item.fdv_per_asset_ada, usd: item.fdv_per_asset_usd, eth: item.fdv_per_asset_eth })
+          ),
         cellClassName: 'font-medium text-white',
       },
       {
@@ -198,7 +205,9 @@ export const VaultTokensStatistics = () => {
         header: 'FDV',
         sortable: true,
         render: item =>
-          currency === 'ada' ? `₳${formatLargeNumber(item.fdv_ada)}` : `$${formatLargeNumber(item.fdv_usd)}`,
+          `${currencySymbol}${formatLargeNumber(
+            pickByCurrency({ ada: item.fdv_ada, usd: item.fdv_usd, eth: item.fdv_eth })
+          )}`,
         cellClassName: 'text-white',
       },
       {
@@ -206,7 +215,9 @@ export const VaultTokensStatistics = () => {
         header: 'TVL',
         sortable: true,
         render: item =>
-          currency === 'ada' ? `₳${formatLargeNumber(item.tvl_ada)}` : `$${formatLargeNumber(item.tvl_usd)}`,
+          `${currencySymbol}${formatLargeNumber(
+            pickByCurrency({ ada: item.tvl_ada, usd: item.tvl_usd, eth: item.tvl_eth })
+          )}`,
         cellClassName: 'text-white',
       },
       {
@@ -226,7 +237,7 @@ export const VaultTokensStatistics = () => {
         ),
       },
     ],
-    [timePeriod, navigate, currency, getPriceChangeValue]
+    [timePeriod, navigate, currencySymbol, pickByCurrency, getPriceChangeValue]
   );
 
   if (error) {

--- a/src/hooks/useCountAnimation.js
+++ b/src/hooks/useCountAnimation.js
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 
 import { formatNum } from '@/utils/core.utils.js';
 
-export const useCountAnimation = (endValue, duration = 2000) => {
+export const useCountAnimation = (endValue, duration = 2000, decimals = 0) => {
   const [count, setCount] = useState(0);
   const countRef = useRef(null);
   const startTime = useRef(null);
@@ -45,7 +45,9 @@ export const useCountAnimation = (endValue, duration = 2000) => {
         return `$${count.toFixed(2)} M`;
       }
     }
-    return formatNum(Math.round(count).toString());
+    // decimals defaults to 0 (whole-number rounding, previous behaviour); callers opt in to
+    // fractional precision where needed (e.g. ETH prices).
+    return formatNum(count, decimals);
   };
 
   return formatCount();

--- a/src/hooks/useCurrency.ts
+++ b/src/hooks/useCurrency.ts
@@ -1,27 +1,33 @@
 import { useState, useEffect, useCallback } from 'react';
 
+type CurrencyType = 'ada' | 'usdt' | 'eth';
+type CurrencySymbol = '₳' | '$' | 'ETH ';
+
 // Normalize currency value to ensure it's always valid
-const normalizeCurrency = (value: string | null): 'ada' | 'usdt' => {
-  return value === 'usdt' ? 'usdt' : 'ada';
+const normalizeCurrency = (value: string | null): CurrencyType => {
+  if (value === 'usdt') return 'usdt';
+  if (value === 'eth') return 'eth';
+  return 'ada';
 };
 
 let globalCurrency = normalizeCurrency(localStorage.getItem('selectedCurrency'));
-const subscribers = new Set<(newCurrency: 'ada' | 'usdt') => void>();
+const subscribers = new Set<(newCurrency: CurrencyType) => void>();
 
-const notifySubscribers = (newCurrency: 'ada' | 'usdt') => {
+const notifySubscribers = (newCurrency: CurrencyType) => {
   globalCurrency = newCurrency;
   subscribers.forEach(callback => callback(newCurrency));
 };
 
 export const useCurrency = (): {
-  currency: 'ada' | 'usdt';
-  currencySymbol: '₳' | '$';
+  currency: CurrencyType;
+  currencySymbol: CurrencySymbol;
   isAda: boolean;
-  updateCurrency: (newCurrency: 'ada' | 'usdt') => void;
+  pickByCurrency: <T>(values: { ada: T; usd: T; eth: T }) => T;
+  updateCurrency: (newCurrency: CurrencyType) => void;
 } => {
-  const [currency, setCurrency] = useState<'ada' | 'usdt'>(globalCurrency);
+  const [currency, setCurrency] = useState<CurrencyType>(globalCurrency);
 
-  const updateLocalCurrency = useCallback((newCurrency: 'ada' | 'usdt') => {
+  const updateLocalCurrency = useCallback((newCurrency: CurrencyType) => {
     setCurrency(newCurrency);
   }, []);
 
@@ -35,13 +41,22 @@ export const useCurrency = (): {
     };
   }, [updateLocalCurrency]);
 
-  const updateCurrency = useCallback((newCurrency: 'ada' | 'usdt') => {
+  const updateCurrency = useCallback((newCurrency: CurrencyType) => {
     localStorage.setItem('selectedCurrency', newCurrency);
     notifySubscribers(newCurrency);
   }, []);
 
-  const currencySymbol: '₳' | '$' = currency === 'ada' ? '₳' : '$';
+  const currencySymbol: CurrencySymbol = currency === 'ada' ? '₳' : currency === 'eth' ? 'ETH ' : '$';
   const isAda = currency === 'ada';
 
-  return { currency, currencySymbol, isAda, updateCurrency };
+  // Select the value matching the active currency. Backend returns ada/usd/eth-denominated
+  // fields side by side, so callers pass all three variants.
+  const pickByCurrency = useCallback(
+    <T>(values: { ada: T; usd: T; eth: T }): T => {
+      return currency === 'ada' ? values.ada : currency === 'eth' ? values.eth : values.usd;
+    },
+    [currency]
+  );
+
+  return { currency, currencySymbol, isAda, pickByCurrency, updateCurrency };
 };

--- a/src/hooks/useInfiniteWalletAssets.ts
+++ b/src/hooks/useInfiniteWalletAssets.ts
@@ -13,8 +13,10 @@ interface WalletAsset {
   isFungibleToken: boolean;
   priceAda: number;
   priceUsd: number;
+  priceEth: number;
   valueAda: number;
   valueUsd: number;
+  valueEth: number;
   metadata?: {
     policyId: string;
     fingerprint?: string;
@@ -40,6 +42,7 @@ interface WalletOverview {
   wallet: string;
   totalValueAda: number;
   totalValueUsd: number;
+  totalValueEth: number;
   lastUpdated: string;
   summary: {
     totalAssets: number;

--- a/src/pages/home/Stats.jsx
+++ b/src/pages/home/Stats.jsx
@@ -15,13 +15,13 @@ const StatCard = ({ value, label }) => (
 );
 
 const ProgressBar = ({ items, title }) => {
-  const { currency, currencySymbol } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
   const total = items.reduce((sum, item) => sum + item.percentage, 0);
 
   const itemsWithValues = items.map(item => ({
     ...item,
-    actualValue: currency === 'ada' ? item.valueAda : item.valueUsd,
+    actualValue: pickByCurrency({ ada: item.valueAda, usd: item.valueUsd, eth: item.valueEth }),
   }));
 
   return (
@@ -79,32 +79,34 @@ const ProgressBar = ({ items, title }) => {
 const Stats = () => {
   const { data } = useStatistics();
   const statistics = data?.data;
-  const { isAda } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
-  const formatCurrency = (adaValue, usdValue) => {
-    if (isAda) {
-      return `₳${formatNum(adaValue)}`;
-    } else {
-      return `$${formatNum(usdValue)}`;
-    }
+  const formatCurrency = (adaValue, usdValue, ethValue) => {
+    return `${currencySymbol}${formatNum(pickByCurrency({ ada: adaValue, usd: usdValue, eth: ethValue }))}`;
   };
 
-  const getTotalValue = (adaValue, usdValue) => {
-    return isAda ? adaValue : usdValue;
+  const getTotalValue = (adaValue, usdValue, ethValue) => {
+    return pickByCurrency({ ada: adaValue, usd: usdValue, eth: ethValue });
   };
 
   const stats = statistics
     ? [
         { label: 'Total Vaults', value: statistics.totalVaults?.toString() || '0' },
         { label: 'Assets', value: statistics.totalAssets?.toString() || '0' },
-        { label: 'Acquired', value: formatCurrency(statistics.totalAcquiredAda, statistics.totalAcquiredUsd) },
-        { label: 'TVL', value: formatCurrency(statistics.totalValueAda, statistics.totalValueUsd) },
+        {
+          label: 'Acquired',
+          value: formatCurrency(statistics.totalAcquiredAda, statistics.totalAcquiredUsd, statistics.totalAcquiredEth),
+        },
+        {
+          label: 'TVL',
+          value: formatCurrency(statistics.totalValueAda, statistics.totalValueUsd, statistics.totalValueEth),
+        },
       ]
     : [
         { label: 'Total Vaults', value: '0' },
         { label: 'Assets', value: '0' },
-        { label: 'Acquired', value: '₳0' },
-        { label: 'TVL', value: '₳0' },
+        { label: 'Acquired', value: `${currencySymbol}0` },
+        { label: 'TVL', value: `${currencySymbol}0` },
       ];
 
   const statusData = statistics?.vaultsByStage
@@ -113,6 +115,7 @@ const Stats = () => {
         percentage: value.percentage,
         valueAda: value.valueAda,
         valueUsd: value.valueUsd,
+        valueEth: value.valueEth,
       }))
     : [];
 
@@ -122,13 +125,15 @@ const Stats = () => {
         percentage: value.percentage,
         valueAda: value.valueAda,
         valueUsd: value.valueUsd,
+        valueEth: value.valueEth,
       }))
     : [];
 
   const totalAmount = statistics?.vaultsByType
     ? getTotalValue(
         Object.values(statistics.vaultsByStage).reduce((sum, stage) => sum + stage.valueAda, 0),
-        Object.values(statistics.vaultsByStage).reduce((sum, stage) => sum + stage.valueUsd, 0)
+        Object.values(statistics.vaultsByStage).reduce((sum, stage) => sum + stage.valueUsd, 0),
+        Object.values(statistics.vaultsByStage).reduce((sum, stage) => sum + stage.valueEth, 0)
       )
     : 0;
 

--- a/src/pages/profile/Stats.jsx
+++ b/src/pages/profile/Stats.jsx
@@ -2,14 +2,14 @@ import { useCurrency } from '@/hooks/useCurrency';
 import { formatNum } from '@/utils/core.utils.js';
 
 export const Stats = ({ user }) => {
-  const { currency } = useCurrency();
+  const { currencySymbol, pickByCurrency } = useCurrency();
 
   return (
     <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
       <div className="bg-input-bg rounded-md p-6">
         <p className="text-dark-100 mb-2">TVL</p>
         <p className="text-2xl font-medium">
-          {currency === 'ada' ? `₳${formatNum(user?.totalValueAda) || 0}` : `$${formatNum(user?.totalValueUsd) || 0}`}
+          {`${currencySymbol}${formatNum(pickByCurrency({ ada: user?.totalValueAda, usd: user?.totalValueUsd, eth: user?.totalValueEth })) || 0}`}
         </p>
       </div>
       <div className="bg-input-bg rounded-md p-6">

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -205,6 +205,7 @@ export interface VaultShortResponse {
   tvl?: number;
   totalValueAda?: number;
   totalValueUsd?: number;
+  totalValueEth?: number;
   baseAllocation?: number;
   total?: number;
   invested?: number;


### PR DESCRIPTION
This pull request adds support for ETH as a display currency throughout the application, updating all relevant components and calculations to handle ETH alongside ADA and USD. The main changes involve updating currency selection options, refactoring logic to use a new `pickByCurrency` utility, and ensuring all value displays and calculations adapt to the selected currency, including proper decimal precision for ETH.

**Currency Support and Selection**
* Added ETH as an available option in the currency selector in `Header.jsx`, allowing users to choose ETH as their display currency.

**Refactoring for Multi-Currency Support**
* Replaced previous ADA/USD-specific logic in all major components (`HeroStats.jsx`, `AcquireModal.jsx`, `ContributeModal.jsx`, `VaultMetrics.jsx`, `VaultAcquiredAssetsList.jsx`, `VaultContributedAssetsList.jsx`, `VaultContributedAssetsCard.jsx`) with the new `pickByCurrency` utility, ensuring all value displays and calculations dynamically select the correct value for ADA, USD, or ETH. [[1]](diffhunk://#diff-a1f343326d56c83ee09cf8e909d6581ed8dcefff0c507f48c21f9ffb3abc544eL19-R26) [[2]](diffhunk://#diff-0bac1e55d423b90e1998b0fdd22b470d61c83c9a3ae7bf7c1a53950796d4d72aL16-R16) [[3]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL25-R25) [[4]](diffhunk://#diff-82c390e12a020776ea96b541878c3ccbbb0a6dfcf13e647d4b1b1b448bb86b32L31-R31) [[5]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2L27-R27) [[6]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL7-R7) [[7]](diffhunk://#diff-3860b1eacae73613e77bfdbaa4d5b6668e99a50bb0dd0286435301ed4c77820fL29-R29)

**Value Display and Calculation Updates**
* Updated all currency value calculations and displays (including TVL, contributed amounts, asset values, and statistics) to support ETH, and ensured correct decimal precision for ETH values (4 decimals) while keeping ADA and USD as whole numbers. [[1]](diffhunk://#diff-a1f343326d56c83ee09cf8e909d6581ed8dcefff0c507f48c21f9ffb3abc544eL40-R45) [[2]](diffhunk://#diff-a1f343326d56c83ee09cf8e909d6581ed8dcefff0c507f48c21f9ffb3abc544eL49-R60) [[3]](diffhunk://#diff-0bac1e55d423b90e1998b0fdd22b470d61c83c9a3ae7bf7c1a53950796d4d72aL238-R242) [[4]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL93-R118) [[5]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL115-R132) [[6]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL139-R183) [[7]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL203-R230) [[8]](diffhunk://#diff-82c390e12a020776ea96b541878c3ccbbb0a6dfcf13e647d4b1b1b448bb86b32R51-R62) [[9]](diffhunk://#diff-82c390e12a020776ea96b541878c3ccbbb0a6dfcf13e647d4b1b1b448bb86b32L64-R71) [[10]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2L86-R92) [[11]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2L99-R120) [[12]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL69-R71) [[13]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL120-R122) [[14]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL132-R134) [[15]](diffhunk://#diff-3860b1eacae73613e77bfdbaa4d5b6668e99a50bb0dd0286435301ed4c77820fL104-R110)

**Component API Changes**
* Updated props and internal logic for asset display components to accept and use the new `pickByCurrency` function instead of the previous `isAda` boolean, making them fully currency-agnostic. [[1]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL7-R7) [[2]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL120-R122) [[3]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL132-R134)

**Calculation Consistency**
* Ensured all calculations for vault metrics, contributed/acquired assets, and modal estimates use the correct exchange rates and values for the selected currency, including deriving ETH prices from ADA as needed. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL93-R118) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL115-R132) [[3]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL139-R183) [[4]](diffhunk://#diff-82c390e12a020776ea96b541878c3ccbbb0a6dfcf13e647d4b1b1b448bb86b32R51-R62)

These changes collectively provide seamless ETH support across the app, ensuring users can view and interact with all values in their preferred currency.