### PR TITLE
small change contribute

### DIFF
--- a/src/components/modals/ContributeModal.jsx
+++ b/src/components/modals/ContributeModal.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
+import { useAccount } from 'wagmi';
 import toast from 'react-hot-toast';
 
 import { ModalWrapper } from '@/components/shared/ModalWrapper.jsx';
@@ -42,6 +43,13 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     'isUpdatingUtxos',
     'changeAddressBech32'
   );
+  // Wallet address is chain-specific: Cardano comes from the weld wallet
+  // (bech32), Robinhood/EVM comes from the wagmi wallet (0x). The backend
+  // resolves the holdings per `chain`, so we just forward the matching address.
+  const { address: evmAddress } = useAccount();
+  const chain = vault?.chainType || 'cardano';
+  const isEvmChain = chain === 'robinhood';
+  const walletAddress = isEvmChain ? evmAddress : wallet?.changeAddressBech32;
   const { sendTransaction, status, error } = useTransaction();
   const { data: vaultAssetsData } = useVaultAssets(vault?.id);
 
@@ -72,11 +80,12 @@ export const ContributeModal = ({ vault, onClose, isOpen, isExpansion }) => {
     loadMoreAssets,
     refresh,
   } = useInfiniteWalletAssets({
-    walletAddress: wallet?.changeAddressBech32,
+    walletAddress,
     whitelistedPolicies,
     activeTab,
     search: searchQuery.trim() || '',
     vaultId: vault?.id, // Pass vault ID for custom pricing
+    chain, // Chain type so the backend resolves the correct wallet holdings
   });
 
   // Calculate estimated value

--- a/src/hooks/useInfiniteWalletAssets.ts
+++ b/src/hooks/useInfiniteWalletAssets.ts
@@ -60,6 +60,7 @@ export const useInfiniteWalletAssets = ({
   whitelistedPolicies,
   search,
   vaultId,
+  chain,
 }: {
   walletAddress: string;
   activeTab: 'NFT' | 'FT' | 'ALL';
@@ -68,6 +69,7 @@ export const useInfiniteWalletAssets = ({
   whitelistedPolicies?: string[];
   search?: string;
   vaultId?: string;
+  chain?: string;
 }) => {
   const [currentPage, setCurrentPage] = useState(1);
   const [allAssets, setAllAssets] = useState<WalletAsset[]>([]);
@@ -91,6 +93,7 @@ export const useInfiniteWalletAssets = ({
     whitelistedPolicies,
     search,
     vaultId,
+    chain,
   });
 
   // Reset when dependencies change
@@ -100,7 +103,7 @@ export const useInfiniteWalletAssets = ({
     setOverview(null);
     setHasNextPage(false);
     loadedPages.current.clear();
-  }, [walletAddress, apiFilter, pageSize, search, vaultId]);
+  }, [walletAddress, apiFilter, pageSize, search, vaultId, chain]);
 
   // Handle new data from the hook
   useEffect(() => {

--- a/src/services/api/queries.ts
+++ b/src/services/api/queries.ts
@@ -308,6 +308,7 @@ export const useWalletSummaryPaginated = ({
   whitelistedPolicies,
   search,
   vaultId,
+  chain,
 }: {
   address: string;
   page?: number;
@@ -316,9 +317,10 @@ export const useWalletSummaryPaginated = ({
   whitelistedPolicies?: string[];
   search?: string;
   vaultId?: string;
+  chain?: string;
 }) => {
   return useQuery({
-    queryKey: ['wallet-summary', address, page, limit, filter, whitelistedPolicies, search, vaultId],
+    queryKey: ['wallet-summary', address, page, limit, filter, whitelistedPolicies, search, vaultId, chain],
     queryFn: () =>
       TapToolsApiProvider.getWalletSummaryPaginated({
         address,
@@ -328,6 +330,7 @@ export const useWalletSummaryPaginated = ({
         whitelistedPolicies,
         search,
         vaultId,
+        chain,
       }),
     enabled: !!address,
   });

--- a/src/services/api/taptools/index.js
+++ b/src/services/api/taptools/index.js
@@ -2,7 +2,16 @@ import { TapToolsConfigProvider } from '@/services/api/taptools/config';
 import { axiosInstance } from '@/services/api';
 
 export class TapToolsApiProvider {
-  static async getWalletSummaryPaginated({ address, page, limit, filter, whitelistedPolicies, search, vaultId }) {
+  static async getWalletSummaryPaginated({
+    address,
+    page,
+    limit,
+    filter,
+    whitelistedPolicies,
+    search,
+    vaultId,
+    chain,
+  }) {
     return await axiosInstance.post(TapToolsConfigProvider.getWalletSummaryPaginated(), {
       address,
       page,
@@ -11,6 +20,7 @@ export class TapToolsApiProvider {
       whitelistedPolicies,
       search,
       vaultId,
+      chain,
     });
   }
 }


### PR DESCRIPTION
This pull request improves multi-chain support for wallet asset fetching and summary queries, particularly enabling proper handling of both Cardano and EVM-based chains. The main changes ensure that the correct wallet address and chain type are forwarded through the stack, so the backend can resolve holdings accurately for each chain.

**Multi-chain wallet address and chain handling:**

* In `ContributeModal.jsx`, added logic to select the correct wallet address (`bech32` for Cardano, `0x` for EVM) and determine the chain type, forwarding both to asset-fetching hooks. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cR3) [[2]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cR46-R52)
* Updated the `useInfiniteWalletAssets` hook and its consumers to accept and forward the `chain` parameter, ensuring asset queries are chain-aware. [[1]](diffhunk://#diff-252be7c677741a2080a318ac7c5e1782b8a1a0fcc08ab62ba94149538dc7092cL75-R88) [[2]](diffhunk://#diff-8f2415f851b436ff85f4f9f0f86ec64e0744363e1a474e71d24f1afcde1f6135R63) [[3]](diffhunk://#diff-8f2415f851b436ff85f4f9f0f86ec64e0744363e1a474e71d24f1afcde1f6135R72) [[4]](diffhunk://#diff-8f2415f851b436ff85f4f9f0f86ec64e0744363e1a474e71d24f1afcde1f6135R96) [[5]](diffhunk://#diff-8f2415f851b436ff85f4f9f0f86ec64e0744363e1a474e71d24f1afcde1f6135L103-R106)

**API and backend integration:**

* Modified `useWalletSummaryPaginated` and its query key to include the `chain` parameter, ensuring cache and queries are chain-specific. [[1]](diffhunk://#diff-502b712f6df782ba521749016cf1b1b7de666c6d7eb298334f37301308739a59R311) [[2]](diffhunk://#diff-502b712f6df782ba521749016cf1b1b7de666c6d7eb298334f37301308739a59R320-R323)
* Updated the `TapToolsApiProvider.getWalletSummaryPaginated` API call to accept and forward the `chain` parameter to the backend payload. [[1]](diffhunk://#diff-502b712f6df782ba521749016cf1b1b7de666c6d7eb298334f37301308739a59R333) [[2]](diffhunk://#diff-194dafe89397bf44b8f9d4e84def16502918769a84a41156b1ab304b194861e2L5-R14) [[3]](diffhunk://#diff-194dafe89397bf44b8f9d4e84def16502918769a84a41156b1ab304b194861e2R23)