### PR TITLE
Run Lint Before Build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,11 +22,11 @@ jobs:
       - name: Install dependencies
         run: yarn install
 
-      - name: Build project
-        run: yarn build
-
       - name: Run linter
         run: yarn lint
+
+      - name: Build project
+        run: yarn build
 
   deploy-dev:
     if: github.ref == 'refs/heads/dev' && github.event_name == 'push'


### PR DESCRIPTION
This pull request makes a minor adjustment to the deployment workflow by reordering the build and lint steps in the `.github/workflows/deploy.yml` file. The linter now runs before the project build step.

- Workflow step order update:
  * In `.github/workflows/deploy.yml`, the "Run linter" step now executes before the "Build project" step to ensure code quality checks are performed prior to building.