### PR TITLE
Feature/fix robinhood eth

### DIFF
--- a/src/components/vault-profile/VaultSettings.jsx
+++ b/src/components/vault-profile/VaultSettings.jsx
@@ -101,7 +101,8 @@ export const VaultSettings = ({ vault }) => {
   };
 
   const isOwner = user?.id === vault.owner.id;
-  const canCancelVaultByOwner = isOwner && vault?.canCancelVault;
+  // Cancel Vault is not supported on Robinhood (EVM) vaults.
+  const canCancelVaultByOwner = isOwner && vault?.canCancelVault && vault?.chainType !== 'robinhood';
 
   const renderAssets = assetsWhitelist => {
     const whitelistedAssets = (assetsWhitelist ?? []).filter(asset => asset.policyId);

--- a/src/components/vaults/CommunityVaultsList.jsx
+++ b/src/components/vaults/CommunityVaultsList.jsx
@@ -5,9 +5,6 @@ import { VaultList } from '@/components/vaults/VaultsList';
 import { useVaults } from '@/services/api/queries';
 import { useNetwork } from '@/hooks/useNetwork';
 
-// Vaults without an explicit network are treated as Cardano.
-const getVaultNetwork = vault => vault?.network || 'cardano';
-
 const VAULT_TABS = [
   { id: 'all', label: 'All', filter: 'all' },
   { id: 'upcoming', label: 'Upcoming', filter: 'published' },
@@ -29,12 +26,15 @@ export const CommunityVaultsList = ({ className = '' }) => {
   const tabParam = search?.tab || DEFAULT_TAB;
   const initialTab = VAULT_TABS.find(tab => tab.id === tabParam) || VAULT_TABS.find(tab => tab.id === DEFAULT_TAB);
 
+  const { network } = useNetwork();
+
   const [activeTab, setActiveTab] = useState(initialTab);
   const [appliedFilters, setAppliedFilters] = useState({
     page: 1,
     limit: 12,
     filter: initialTab.filter,
     search: '',
+    chainType: network,
   });
 
   useEffect(() => {
@@ -46,6 +46,15 @@ export const CommunityVaultsList = ({ className = '' }) => {
       filter: newTab.filter,
     }));
   }, [tabParam]);
+
+  // Keep the vault search in sync with the network selected in the header.
+  useEffect(() => {
+    setAppliedFilters(prevFilters => ({
+      ...prevFilters,
+      chainType: network,
+      page: 1,
+    }));
+  }, [network]);
 
   const handleSearch = useCallback(searchText => {
     setAppliedFilters(prevFilters => ({
@@ -73,10 +82,8 @@ export const CommunityVaultsList = ({ className = '' }) => {
     }
   };
 
-  const { network } = useNetwork();
-
   const { data, isLoading, error } = useVaults(appliedFilters);
-  const vaults = (data?.data?.items || []).filter(vault => getVaultNetwork(vault) === network);
+  const vaults = data?.data?.items || [];
 
   const pagination = data?.data
     ? {
@@ -92,6 +99,7 @@ export const CommunityVaultsList = ({ className = '' }) => {
       page: 1,
       limit: prevFilters.limit || 12,
       filter: prevFilters.filter || 'contribution',
+      chainType: network,
       ...filters,
     }));
   };


### PR DESCRIPTION
This pull request updates the vault listing and settings logic to improve network handling and filtering. The main changes ensure that vault lists are consistently filtered by the selected network, and that certain actions are restricted based on vault type.

**Network selection and vault filtering:**

* The vault list now automatically syncs with the network selected in the header, updating filters and resetting pagination when the network changes. [[1]](diffhunk://#diff-1e42a0942911ab890e1aa1fdfb90a8a74c9b94790626d0c5081853213c84c32dR29-R37) [[2]](diffhunk://#diff-1e42a0942911ab890e1aa1fdfb90a8a74c9b94790626d0c5081853213c84c32dR50-R58)
* The `chainType` filter is now included in all vault searches, ensuring only vaults from the selected network are shown. The previous manual network filtering of results has been removed for efficiency and consistency. [[1]](diffhunk://#diff-1e42a0942911ab890e1aa1fdfb90a8a74c9b94790626d0c5081853213c84c32dL76-R86) [[2]](diffhunk://#diff-1e42a0942911ab890e1aa1fdfb90a8a74c9b94790626d0c5081853213c84c32dR29-R37) [[3]](diffhunk://#diff-1e42a0942911ab890e1aa1fdfb90a8a74c9b94790626d0c5081853213c84c32dR102)
* The unused `getVaultNetwork` helper was removed, as network filtering is now handled by the query itself.

**Vault action restrictions:**

* Owners can no longer cancel vaults on the Robinhood (EVM) chain, as this action is not supported for these vaults.