### PR TITLE
Filter statistics by chain

### DIFF
--- a/src/components/HeroStats.jsx
+++ b/src/components/HeroStats.jsx
@@ -1,6 +1,7 @@
 import { useCountAnimation } from '@/hooks/useCountAnimation';
 import { useStatistics } from '@/services/api/queries';
 import { useCurrency } from '@/hooks/useCurrency';
+import { useNetwork } from '@/hooks/useNetwork';
 
 const Counter = ({ value, prefix = '', decimals = 0 }) => {
   const animatedValue = useCountAnimation(value, 2000, decimals);
@@ -13,7 +14,8 @@ const Counter = ({ value, prefix = '', decimals = 0 }) => {
 };
 
 const HeroStats = () => {
-  const { data } = useStatistics();
+  const { network } = useNetwork();
+  const { data } = useStatistics({ chainType: network });
   const stats = data?.data;
   const { currencySymbol, pickByCurrency } = useCurrency();
 

--- a/src/services/api/queries.ts
+++ b/src/services/api/queries.ts
@@ -29,10 +29,10 @@ export const useAcquire = () => {
   });
 };
 
-export const useStatistics = () => {
+export const useStatistics = (params = {}) => {
   return useQuery({
-    queryKey: ['statistics'],
-    queryFn: () => VaultsApiProvider.getStatistics(),
+    queryKey: ['statistics', params],
+    queryFn: () => VaultsApiProvider.getStatistics(params),
   });
 };
 

--- a/src/services/api/vaults/index.js
+++ b/src/services/api/vaults/index.js
@@ -16,8 +16,8 @@ export class VaultsApiProvider {
     return response;
   }
 
-  static async getStatistics() {
-    const response = await axiosInstance.get(VaultsConfigProvider.getStatistics());
+  static async getStatistics(params = {}) {
+    const response = await axiosInstance.get(VaultsConfigProvider.getStatistics(), { params });
     return response;
   }
 


### PR DESCRIPTION
This pull request updates how statistics are fetched and displayed in the app, adding support for network-specific statistics. The main change is that statistics are now requested with the current network as a parameter, allowing the app to show data relevant to the selected network.

**Network-aware statistics fetching:**

- Updated `HeroStats` to use the current network from `useNetwork` and pass it as a parameter to `useStatistics`, so statistics are fetched for the selected network. [[1]](diffhunk://#diff-a1f343326d56c83ee09cf8e909d6581ed8dcefff0c507f48c21f9ffb3abc544eR4) [[2]](diffhunk://#diff-a1f343326d56c83ee09cf8e909d6581ed8dcefff0c507f48c21f9ffb3abc544eL16-R18)
- Modified `useStatistics` hook to accept parameters and include them in the query key and API call, enabling dynamic statistics requests.
- Updated `VaultsApiProvider.getStatistics` to accept and forward parameters as query params in the API request, supporting network-specific data retrieval.