### PR TITLE
hotfix/statistics

### DIFF
--- a/src/pages/home/Stats.jsx
+++ b/src/pages/home/Stats.jsx
@@ -1,6 +1,7 @@
 import { formatNum } from '@/utils/core.utils.js';
 import { useStatistics } from '@/services/api/queries';
 import { useCurrency } from '@/hooks/useCurrency';
+import { useNetwork } from '@/hooks/useNetwork';
 
 const getBackgroundColor = index => {
   const colors = ['#c10007', '#e7000b', '#fb2c36', '#ff6467'];
@@ -77,7 +78,8 @@ const ProgressBar = ({ items, title }) => {
 };
 
 const Stats = () => {
-  const { data } = useStatistics();
+  const { network } = useNetwork();
+  const { data } = useStatistics({ chainType: network });
   const statistics = data?.data;
   const { currencySymbol, pickByCurrency } = useCurrency();
 


### PR DESCRIPTION
This pull request updates the `Stats` component to make the displayed statistics responsive to the selected network. The most important changes are:

**Network-aware statistics:**

* The `Stats` component now uses the `useNetwork` hook to get the current network and passes it as a `chainType` parameter to the `useStatistics` query, ensuring statistics are fetched for the correct network. [[1]](diffhunk://#diff-1cf96c8476f22d711ad4c1910774f8c9fe4da6d3fd632478b40a8b22e3989763R4) [[2]](diffhunk://#diff-1cf96c8476f22d711ad4c1910774f8c9fe4da6d3fd632478b40a8b22e3989763L80-R82)