### PR TITLE
Track EVM wallet changes and disconnect

### DIFF
--- a/src/hooks/useWalletChangeListener.js
+++ b/src/hooks/useWalletChangeListener.js
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react';
 import { useWallet } from '@ada-anvil/weld/react';
+import { useAccount } from 'wagmi';
 
 import { useAuth } from '@/lib/auth/auth';
 import { useNetwork } from '@/hooks/useNetwork';
@@ -14,9 +15,12 @@ const checkWeldCookies = () => {
 
 export const useWalletChangeListener = () => {
   const wallet = useWallet('isConnected', 'stakeAddressBech32');
+  const { address: evmAddress, status: evmStatus } = useAccount();
   const { user, logout, isAuthenticated } = useAuth();
   const { isRobinHood } = useNetwork();
   const previousStakeAddressRef = useRef(null);
+  const previousEvmAddressRef = useRef(null);
+  const evmDisconnectedLogoutTimerRef = useRef(null);
 
   // Proactively clear DexHunter localStorage when auth/wallet becomes invalid
   useEffect(() => {
@@ -57,6 +61,81 @@ export const useWalletChangeListener = () => {
       previousStakeAddressRef.current = null;
     }
   }, [wallet.isConnected, wallet.stakeAddressBech32, user, isAuthenticated, logout, isRobinHood]);
+
+  useEffect(() => {
+    // EVM (Robinhood) watchdog — mirrors the Cardano branch using wagmi's MetaMask/injected state.
+    if (!isRobinHood || !isAuthenticated || !user) {
+      previousEvmAddressRef.current = null;
+      if (evmDisconnectedLogoutTimerRef.current) {
+        clearTimeout(evmDisconnectedLogoutTimerRef.current);
+        evmDisconnectedLogoutTimerRef.current = null;
+      }
+      return;
+    }
+
+    // wagmi reconnects asynchronously on load; wait for a settled state so we don't
+    // log out during 'connecting' / 'reconnecting'.
+    if (evmStatus === 'connecting' || evmStatus === 'reconnecting') {
+      if (evmDisconnectedLogoutTimerRef.current) {
+        clearTimeout(evmDisconnectedLogoutTimerRef.current);
+        evmDisconnectedLogoutTimerRef.current = null;
+      }
+      return;
+    }
+
+    if (evmStatus === 'connected' && evmAddress) {
+      if (evmDisconnectedLogoutTimerRef.current) {
+        clearTimeout(evmDisconnectedLogoutTimerRef.current);
+        evmDisconnectedLogoutTimerRef.current = null;
+      }
+
+      const authenticatedEvmAddress = localStorage.getItem('authenticated_wallet_address');
+      if (authenticatedEvmAddress && authenticatedEvmAddress.toLowerCase() !== evmAddress.toLowerCase()) {
+        logout('Wallet changed. Please login again.');
+        previousEvmAddressRef.current = null;
+        return;
+      }
+
+      // First settled connection — record it as the baseline.
+      if (!previousEvmAddressRef.current) {
+        previousEvmAddressRef.current = evmAddress;
+        return;
+      }
+
+      if (previousEvmAddressRef.current.toLowerCase() !== evmAddress.toLowerCase()) {
+        logout('Wallet changed. Please login again.');
+        previousEvmAddressRef.current = null;
+      }
+      return;
+    }
+
+    if (evmStatus === 'disconnected' && previousEvmAddressRef.current) {
+      logout('Wallet disconnected. Please login again.');
+      previousEvmAddressRef.current = null;
+      return;
+    }
+
+    // On a fresh page load the in-memory previous address is empty, so also
+    // treat an authenticated EVM session with a disconnected wallet as invalid.
+    if (evmStatus === 'disconnected' && !evmDisconnectedLogoutTimerRef.current) {
+      evmDisconnectedLogoutTimerRef.current = setTimeout(() => {
+        evmDisconnectedLogoutTimerRef.current = null;
+        if (!localStorage.getItem('jwt')) return;
+
+        const authenticatedChainType = localStorage.getItem('authenticated_chain_type');
+        if (authenticatedChainType && authenticatedChainType !== 'robinhood') return;
+
+        logout('Wallet disconnected. Please login again.');
+      }, 500);
+    }
+
+    return () => {
+      if (evmDisconnectedLogoutTimerRef.current) {
+        clearTimeout(evmDisconnectedLogoutTimerRef.current);
+        evmDisconnectedLogoutTimerRef.current = null;
+      }
+    };
+  }, [isRobinHood, isAuthenticated, user, evmAddress, evmStatus, logout]);
 
   useEffect(() => {
     // Weld cookie check would fire for EVM logins (no Weld cookies) and wrongly log them out.

--- a/src/lib/auth/auth.context.jsx
+++ b/src/lib/auth/auth.context.jsx
@@ -26,7 +26,21 @@ export const AuthProvider = ({ children }) => {
         chainType,
       });
       localStorage.setItem('jwt', response.data.accessToken);
-      localStorage.setItem('authenticated_stake_address', stakeAddress);
+      if (stakeAddress) {
+        localStorage.setItem('authenticated_stake_address', stakeAddress);
+      } else {
+        localStorage.removeItem('authenticated_stake_address');
+      }
+      if (walletAddress) {
+        localStorage.setItem('authenticated_wallet_address', walletAddress);
+      } else {
+        localStorage.removeItem('authenticated_wallet_address');
+      }
+      if (chainType) {
+        localStorage.setItem('authenticated_chain_type', chainType);
+      } else {
+        localStorage.removeItem('authenticated_chain_type');
+      }
       queryClient.setQueryData(['profile'], { data: response.data.user });
       return response.data;
     } catch (error) {

--- a/src/lib/auth/auth.js
+++ b/src/lib/auth/auth.js
@@ -4,6 +4,8 @@ import { createContext, useContext } from 'react';
 export function clearAuthLocalStorage() {
   localStorage.removeItem('jwt');
   localStorage.removeItem('authenticated_stake_address');
+  localStorage.removeItem('authenticated_wallet_address');
+  localStorage.removeItem('authenticated_chain_type');
   localStorage.removeItem('vlrm_balance_cache');
   localStorage.removeItem('storageVault');
 


### PR DESCRIPTION
This pull request enhances wallet authentication handling, especially for EVM (Robinhood) wallets, by adding robust detection and logout logic when the wallet address changes or disconnects. It also ensures that relevant authentication data is consistently managed in localStorage.

**EVM Wallet Authentication & Logout Handling:**

* Added a new effect in `useWalletChangeListener.js` to monitor EVM wallet state via `wagmi` and proactively log out users if their wallet address changes or disconnects, mirroring the Cardano wallet logic.
* Introduced refs (`previousEvmAddressRef`, `evmDisconnectedLogoutTimerRef`) to track the last known EVM address and debounce logout on disconnect.
* Ensured that on login, `authenticated_wallet_address` and `authenticated_chain_type` are set or removed in localStorage as appropriate.
* Updated `clearAuthLocalStorage` to remove `authenticated_wallet_address` and `authenticated_chain_type` on logout.

**Dependency Updates:**

* Added import of `useAccount` from `wagmi` in `useWalletChangeListener.js` to access EVM wallet state.