### PR TITLE
Fix/UI

### DIFF
--- a/src/components/rewards/AlignmentBonusDisplay.jsx
+++ b/src/components/rewards/AlignmentBonusDisplay.jsx
@@ -25,6 +25,8 @@ const getOracleTier = balance => {
   return null;
 };
 
+const roundPercent = value => Number((Number(value) || 0).toFixed(2));
+
 export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
   const navigate = useNavigate();
 
@@ -45,8 +47,8 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
   const oracleBonus = bonuses.oracle || {};
   const alignmentFullBonus = bonuses.alignment || {};
 
-  const totalBonusPercent = alignmentData?.multiplierPercent || 0;
-  const maxBonusPercent = alignmentData?.maxMultiplierPercent || 20;
+  const totalBonusPercent = roundPercent(alignmentData?.multiplierPercent);
+  const maxBonusPercent = roundPercent(alignmentData?.maxMultiplierPercent || 20);
 
   const oracleTier = getOracleTier(oracleBonus.balance || 0);
 
@@ -55,7 +57,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
       label: 'L4VA Staking',
       clickable: true,
       requirement: `Stake at least ${l4vaBonus.requiredAmount?.toLocaleString() || '100,000'} L4VA`,
-      bonus: l4vaBonus.bonusPercent || 5,
+      bonus: roundPercent(l4vaBonus.bonusPercent || 5),
       achieved: l4vaBonus.achieved,
       progress: l4vaBonus.requiredAmount ? Math.min(100, (l4vaBonus.stakedAmount / l4vaBonus.requiredAmount) * 100) : 0,
       stakedAmount: l4vaBonus.stakedAmount || 0,
@@ -66,7 +68,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
       label: 'VLRM Staking',
       clickable: true,
       requirement: `Stake at least ${vlrmBonus.requiredAmount?.toLocaleString() || '20,000'} VLRM`,
-      bonus: vlrmBonus.bonusPercent || 5,
+      bonus: roundPercent(vlrmBonus.bonusPercent || 5),
       achieved: vlrmBonus.achieved,
       progress: vlrmBonus.requiredAmount ? Math.min(100, (vlrmBonus.stakedAmount / vlrmBonus.requiredAmount) * 100) : 0,
       stakedAmount: vlrmBonus.stakedAmount || 0,
@@ -78,7 +80,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
       clickable: true,
       vaultId: ORACLE_VAULT_ID,
       requirement: oracleTier ? oracleTier.label : 'Hold at least 100 ORACLE',
-      bonus: oracleBonus.bonusPercent || 0,
+      bonus: roundPercent(oracleBonus.bonusPercent),
       achieved: oracleBonus.achieved,
       progress: oracleBonus.achieved ? 100 : 0,
       balance: oracleBonus.balance || 0,
@@ -88,7 +90,7 @@ export const AlignmentBonusDisplay = ({ alignmentData, isLoading = false }) => {
     {
       label: 'Full Alignment',
       requirement: 'All three conditions met (L4VA + VLRM + ORACLE)',
-      bonus: alignmentFullBonus.bonusPercent || 5,
+      bonus: roundPercent(alignmentFullBonus.bonusPercent || 5),
       achieved: alignmentFullBonus.achieved,
       progress: alignmentFullBonus.achieved ? 100 : 0,
       isFullAlignment: true,

--- a/src/components/rewards/EpochRewardRow.jsx
+++ b/src/components/rewards/EpochRewardRow.jsx
@@ -14,11 +14,13 @@ export const EpochRewardRow = ({ epoch, reward = null, score = null, onClick = n
       className={`p-4 bg-gray-800/50 border border-gray-700/50 rounded-lg hover:bg-gray-800/70 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
       onClick={onClick}
     >
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">
         {/* Epoch Info */}
-        <div className="flex-1">
-          <div className="flex items-center gap-3 mb-2">
-            <h4 className="font-semibold text-white">{epochLabel ? `Epoch ${epochLabel}` : 'Epoch'}</h4>
+        <div className="min-w-0">
+          <div className="flex items-center flex-wrap gap-2 mb-2">
+            <h4 className="font-semibold text-white whitespace-nowrap">
+              {epochLabel ? `Epoch ${epochLabel}` : 'Epoch'}
+            </h4>
             <EpochStatusBadge status={epoch.status} />
             {isCapped && (
               <div className="px-2 py-0.5 bg-yellow-500/10 border border-yellow-500/30 rounded text-xs text-yellow-400">
@@ -30,7 +32,7 @@ export const EpochRewardRow = ({ epoch, reward = null, score = null, onClick = n
         </div>
 
         {/* Reward Info */}
-        <div className="text-right">
+        <div className="text-left sm:text-right shrink-0">
           {hasReward ? (
             <>
               <div className="text-2xl font-bold text-white mb-1">{formatCompactNumber(reward.finalReward)} $L4VA</div>

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -719,7 +719,7 @@ export const LavaWhitelistWithCaps = ({
                             ? [{ name: 'lp_token_dynamic', label: 'LP Token Price' }]
                             : [
                                 { name: 'market', label: 'Market / Floor Price' },
-                                { name: 'custom', label: 'Custom Price' },
+                                ...(isRobinHood ? [] : [{ name: 'custom', label: 'Custom Price' }]),
                               ]
                         }
                         value={asset.isLpToken ? 'lp_token_dynamic' : asset.valuationMethod || 'market'}
@@ -743,7 +743,7 @@ export const LavaWhitelistWithCaps = ({
                       })()}
                     </div>
 
-                    {asset.valuationMethod === 'custom' && !asset.isLpToken && (
+                    {asset.valuationMethod === 'custom' && !asset.isLpToken && !isRobinHood && (
                       <div>
                         {renderInput({
                           required: true,

--- a/src/components/vault-profile/VaultAcquiredAssetsList.jsx
+++ b/src/components/vault-profile/VaultAcquiredAssetsList.jsx
@@ -25,6 +25,7 @@ const StatBadge = ({ icon: Icon, label, value }) => (
 export const VaultAcquiredAssetsList = ({ vault }) => {
   const [expandedAsset, setExpandedAsset] = useState(null);
   const { currencySymbol, pickByCurrency } = useCurrency();
+  const isEth = vault?.chainType === 'robinhood';
   const limit = 10;
 
   const [appliedFilters, setAppliedFilters] = useState({
@@ -202,7 +203,7 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
                         }}
                       />
                     </td>
-                    <td className="px-4 py-3 font-medium">ADA</td>
+                    <td className="px-4 py-3 font-medium">{isEth ? 'ETH' : 'ADA'}</td>
                     <td className="px-4 py-3 capitalize">{asset.type}</td>
                     <td className="px-4 py-3 capitalize">{asset.status}</td>
                     <td className="px-4 py-3">{formatNum(asset.quantity, 6)}</td>
@@ -223,38 +224,42 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
                     <tr className="bg-steel-750">
                       <td colSpan="6" className="px-4 py-2">
                         <div className="grid grid-cols-2 gap-4 text-sm text-gray-400">
-                          <div>
-                            <p className="font-medium">Policy ID:</p>
-                            <div className="flex items-center gap-2">
-                              <p className="break-all">{substringAddress(asset.policyId)}</p>
-                              <button
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  navigator.clipboard.writeText(asset.policyId);
-                                  toast.success('Policy ID copied to clipboard');
-                                }}
-                                className="p-1 hover:bg-steel-850 rounded-md transition-colors"
-                              >
-                                <Copy className="w-4 h-4" />
-                              </button>
+                          {!isEth && (
+                            <div>
+                              <p className="font-medium">Policy ID:</p>
+                              <div className="flex items-center gap-2">
+                                <p className="break-all">{substringAddress(asset.policyId)}</p>
+                                <button
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    navigator.clipboard.writeText(asset.policyId);
+                                    toast.success('Policy ID copied to clipboard');
+                                  }}
+                                  className="p-1 hover:bg-steel-850 rounded-md transition-colors"
+                                >
+                                  <Copy className="w-4 h-4" />
+                                </button>
+                              </div>
                             </div>
-                          </div>
-                          <div>
-                            <p className="font-medium">Asset ID:</p>
-                            <div className="flex items-center gap-2">
-                              <p className="break-all">{substringAddress(asset.assetId)}</p>
-                              <button
-                                onClick={e => {
-                                  e.stopPropagation();
-                                  navigator.clipboard.writeText(asset.assetId);
-                                  toast.success('Asset ID copied to clipboard');
-                                }}
-                                className="p-1 hover:bg-steel-850 rounded-md transition-colors"
-                              >
-                                <Copy className="w-4 h-4" />
-                              </button>
+                          )}
+                          {!isEth && (
+                            <div>
+                              <p className="font-medium">Asset ID:</p>
+                              <div className="flex items-center gap-2">
+                                <p className="break-all">{substringAddress(asset.assetId)}</p>
+                                <button
+                                  onClick={e => {
+                                    e.stopPropagation();
+                                    navigator.clipboard.writeText(asset.assetId);
+                                    toast.success('Asset ID copied to clipboard');
+                                  }}
+                                  className="p-1 hover:bg-steel-850 rounded-md transition-colors"
+                                >
+                                  <Copy className="w-4 h-4" />
+                                </button>
+                              </div>
                             </div>
-                          </div>
+                          )}
                           <div>
                             <p className="font-medium">Added At:</p>
                             <p>{new Date(asset.addedAt).toLocaleDateString()}</p>

--- a/src/components/vault-profile/VaultAcquiredAssetsList.jsx
+++ b/src/components/vault-profile/VaultAcquiredAssetsList.jsx
@@ -178,7 +178,6 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
               <tr className="text-dark-100 text-sm border-b border-steel-750">
                 <th className="px-4 py-3 text-left">Image</th>
                 <th className="px-4 py-3 text-left">Name</th>
-                <th className="px-4 py-3 text-left">Type</th>
                 <th className="px-4 py-3 text-left">Status</th>
                 <th className="px-4 py-3 text-left">Quantity</th>
                 <th className="px-4 py-3"></th>
@@ -204,7 +203,6 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
                       />
                     </td>
                     <td className="px-4 py-3 font-medium">{isEth ? 'ETH' : 'ADA'}</td>
-                    <td className="px-4 py-3 capitalize">{asset.type}</td>
                     <td className="px-4 py-3 capitalize">{asset.status}</td>
                     <td className="px-4 py-3">{formatNum(asset.quantity, 6)}</td>
                     <td className="px-4 py-3 text-center">
@@ -222,7 +220,7 @@ export const VaultAcquiredAssetsList = ({ vault }) => {
                   </tr>
                   {expandedAsset === index && (
                     <tr className="bg-steel-750">
-                      <td colSpan="6" className="px-4 py-2">
+                      <td colSpan="5" className="px-4 py-2">
                         <div className="grid grid-cols-2 gap-4 text-sm text-gray-400">
                           {!isEth && (
                             <div>

--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -597,7 +597,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
         setIsSubmitting(true);
         try {
           await vaultSchema.validate(vaultData, { abortEarly: false });
-          const formattedData = formatVaultData(vaultData);
+          const formattedData = formatVaultData(vaultData, isRobinHood);
           setErrors({});
 
           const { dbVaultId } = await createEvmVault(formattedData);
@@ -675,7 +675,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
       try {
         await vaultSchema.validate(vaultData, { abortEarly: false });
 
-        const formattedData = formatVaultData(vaultData);
+        const formattedData = formatVaultData(vaultData, isRobinHood);
         setErrors({});
 
         const { data } = await VaultsApiProvider.createVault(formattedData);
@@ -740,7 +740,7 @@ export const CreateVaultForm = ({ vault, setVault }) => {
   const saveDraft = async () => {
     try {
       setIsSavingDraft(true);
-      const formattedData = formatVaultData(vaultData);
+      const formattedData = formatVaultData(vaultData, isRobinHood);
       const existingDraftId = vaultData?.id ?? vault?.id;
       if (existingDraftId) {
         formattedData.id = existingDraftId;
@@ -898,7 +898,9 @@ export const CreateVaultForm = ({ vault, setVault }) => {
           />
         );
       case 2:
-        return <AssetContribution data={vaultData} errors={errors} updateField={updateField} />;
+        return (
+          <AssetContribution data={vaultData} errors={errors} updateField={updateField} isRobinHood={isRobinHood} />
+        );
       case 3:
         return (
           <AcquireWindow

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -365,10 +365,10 @@ export const vaultSchema = yup.object({
   isAcquireOnly: yup.boolean().default(false),
   minAcquireThreshold: yup
     .number()
-    .typeError('Minimum ADA threshold must be a number')
+    .typeError('Minimum threshold must be a number')
     .when('isAcquireOnly', {
       is: true,
-      then: schema => schema.nullable().positive('Must be a positive number').integer('Must be a whole number of ADA'),
+      then: schema => schema.nullable().positive('Must be a positive number'),
       otherwise: schema => schema.nullable().notRequired(),
     }),
 
@@ -621,7 +621,7 @@ export const initialVaultState = {
   acquireReserve: null,
   liquidityPoolContribution: null,
   isAcquireOnly: false,
-  minAcquireThreshold: null, // in ADA (converted to lovelace before API call)
+  minAcquireThreshold: null, // in ADA (converted to lovelace before API call) on Cardano, in ETH as-is on Robinhood
   allowAcquireExpansion: false,
 
   // Step 4: Governance

--- a/src/components/vaults/steps/AcquireWindow.jsx
+++ b/src/components/vaults/steps/AcquireWindow.jsx
@@ -6,6 +6,7 @@ import { LavaRadio } from '@/components/shared/LavaRadio';
 import { LavaDatePicker } from '@/components/shared/LavaDatePicker';
 import { LavaIntervalPicker } from '@/components/shared/LavaIntervalPicker';
 import { LavaInput } from '@/components/shared/LavaInput';
+import { useNetwork } from '@/hooks/useNetwork';
 import {
   RESERVE_HINT,
   LIQUIDITY_POOL_CONTRIBUTION_HINT,
@@ -20,6 +21,8 @@ export const AcquireWindow = ({
   isAdvancedPresetAvailable = true,
 }) => {
   const isAcquireOnly = data.isAcquireOnly === true;
+  const { isRobinHood } = useNetwork();
+  const assetSymbol = isRobinHood ? 'ETH' : 'ADA';
 
   const handleChange = e => {
     const { name, value } = e.target;
@@ -103,7 +106,7 @@ export const AcquireWindow = ({
         {isAcquireOnly && (
           <div>
             <Label className="uppercase font-bold" htmlFor="minAcquireThreshold">
-              MINIMUM ADA THRESHOLD (OPTIONAL)
+              MINIMUM {assetSymbol} THRESHOLD (OPTIONAL)
             </Label>
             <div className="mt-4">
               <LavaInput
@@ -111,8 +114,8 @@ export const AcquireWindow = ({
                 label=""
                 id="minAcquireThreshold"
                 name="minAcquireThreshold"
-                placeholder="e.g. 10000"
-                suffix="ADA"
+                placeholder={isRobinHood ? 'e.g. 0.01' : 'e.g. 10000'}
+                suffix={assetSymbol}
                 type="text"
                 value={
                   data.minAcquireThreshold !== null && data.minAcquireThreshold !== undefined
@@ -120,13 +123,18 @@ export const AcquireWindow = ({
                     : ''
                 }
                 onChange={e => {
+                  if (isRobinHood) {
+                    const raw = e.target.value.replace(/[^0-9.]/g, '').replace(/(\..*)\./g, '$1');
+                    updateField('minAcquireThreshold', raw === '' ? null : raw);
+                    return;
+                  }
                   const raw = e.target.value.replace(/[^0-9]/g, '');
                   updateField('minAcquireThreshold', raw === '' ? null : Number(raw));
                 }}
                 hint={
                   data.liquidityPoolContribution > 0
-                    ? `Optional. Sets the minimum ADA required for the vault to lock. Important: When LP Contribution is ${data.liquidityPoolContribution}%, the vault needs enough ADA to meet BOTH your minimum threshold AND the LP minimum liquidity requirement. If either threshold is not met, the vault will fail and all ADA is refunded. If not set, only the LP minimum must be met.`
-                    : 'Optional. If set, the vault will only lock if this minimum amount of ADA is acquired. If not set, the vault will lock if ANY amount of ADA is acquired. If no ADA is acquired, the vault will fail and all ADA is refunded.'
+                    ? `Optional. Sets the minimum ${assetSymbol} required for the vault to lock. Important: When LP Contribution is ${data.liquidityPoolContribution}%, the vault needs enough ${assetSymbol} to meet BOTH your minimum threshold AND the LP minimum liquidity requirement. If either threshold is not met, the vault will fail and all ${assetSymbol} is refunded. If not set, only the LP minimum must be met.`
+                    : `Optional. If set, the vault will only lock if this minimum amount of ${assetSymbol} is acquired. If not set, the vault will lock if ANY amount of ${assetSymbol} is acquired. If no ${assetSymbol} is acquired, the vault will fail and all ${assetSymbol} is refunded.`
                 }
               />
               {data.liquidityPoolContribution > 0 && (
@@ -134,7 +142,7 @@ export const AcquireWindow = ({
                   Warning. With {data.liquidityPoolContribution}% LP Contribution, your vault has TWO thresholds that
                   must be met:
                   <br />
-                  1. Your minimum ADA threshold (if set)
+                  1. Your minimum {assetSymbol} threshold (if set)
                   <br />
                   2. LP minimum liquidity requirement (calculated automatically)
                   <br />

--- a/src/components/vaults/steps/AssetContribution/Private.jsx
+++ b/src/components/vaults/steps/AssetContribution/Private.jsx
@@ -10,8 +10,14 @@ import {
   MIN_CONTRIBUTION_DURATION_MS,
 } from '@/components/vaults/constants/vaults.constants';
 
-export const Private = ({ data, errors = {}, updateField }) => {
+export const Private = ({ data, errors = {}, updateField, isRobinHood = false }) => {
   const { valueMethod, privacy: vaultPrivacy } = data;
+
+  const valuationCurrencyOptions = [
+    ...(isRobinHood ? [] : [{ id: 'ADA', label: 'ADA' }]),
+    { id: 'USD', label: 'USD' },
+    ...(isRobinHood ? [{ id: 'ETH', label: 'ETH' }] : []),
+  ];
 
   const valueMethodOptions =
     vaultPrivacy === VAULT_PRIVACY_TYPES.PRIVATE
@@ -48,10 +54,7 @@ export const Private = ({ data, errors = {}, updateField }) => {
                 required
                 error={errors.valuationCurrency}
                 label="Valuation Currency"
-                options={[
-                  { id: 'ADA', label: 'ADA' },
-                  { id: 'USD', label: 'USD' },
-                ]}
+                options={valuationCurrencyOptions}
                 placeholder="Select currency"
                 value={data.valuationCurrency || ''}
                 onChange={value => updateField('valuationCurrency', value)}

--- a/src/components/vaults/steps/AssetContribution/index.jsx
+++ b/src/components/vaults/steps/AssetContribution/index.jsx
@@ -3,13 +3,14 @@ import { Private } from '@/components/vaults/steps/AssetContribution/Private';
 import { SemiPrivate } from '@/components/vaults/steps/AssetContribution/SemiPrivate';
 import { VAULT_PRIVACY_TYPES } from '@/components/vaults/constants/vaults.constants';
 
-export const AssetContribution = ({ data, errors = {}, updateField }) => {
+export const AssetContribution = ({ data, errors = {}, updateField, isRobinHood = false }) => {
   const vaultPrivacy = data.privacy;
 
   const props = {
     data,
     errors,
     updateField,
+    isRobinHood,
   };
 
   if (vaultPrivacy === VAULT_PRIVACY_TYPES.PUBLIC) {

--- a/src/components/vaults/utils/vaults.utils.js
+++ b/src/components/vaults/utils/vaults.utils.js
@@ -1,4 +1,4 @@
-export const formatVaultData = vaultData => {
+export const formatVaultData = (vaultData, isRobinHood = false) => {
   const formattedData = { ...vaultData };
 
   if (formattedData.socialLinks.length > 0) {
@@ -6,9 +6,11 @@ export const formatVaultData = vaultData => {
     formattedData.socialLinks = formattedData.socialLinks.map(({ id, ...rest }) => rest);
   }
 
-  // Convert minAcquireThreshold from ADA to lovelace for the API
+  // Cardano sends minAcquireThreshold in lovelace; Robinhood (EVM) sends it in ETH as entered.
   if (formattedData.isAcquireOnly && formattedData.minAcquireThreshold != null) {
-    formattedData.minAcquireThreshold = Math.round(Number(formattedData.minAcquireThreshold) * 1000000);
+    formattedData.minAcquireThreshold = isRobinHood
+      ? Number(formattedData.minAcquireThreshold)
+      : Math.round(Number(formattedData.minAcquireThreshold) * 1000000);
   }
 
   return formattedData;

--- a/src/hooks/useRewardsEpochs.ts
+++ b/src/hooks/useRewardsEpochs.ts
@@ -3,12 +3,12 @@ import { useQuery } from '@tanstack/react-query';
 import { RewardsApiProvider } from '@/services/api/rewards';
 
 /**
- * Fetch all epochs
+ * Fetch paginated epochs
  */
-export const useEpochs = () => {
+export const useEpochs = (limit = 20, offset = 0) => {
   return useQuery({
-    queryKey: ['rewards', 'epochs'],
-    queryFn: () => RewardsApiProvider.getEpochs(),
+    queryKey: ['rewards', 'epochs', limit, offset],
+    queryFn: () => RewardsApiProvider.getEpochs(limit, offset),
     staleTime: 1000 * 60 * 5, // 5 minutes
   });
 };

--- a/src/pages/rewards/EpochsList.jsx
+++ b/src/pages/rewards/EpochsList.jsx
@@ -8,6 +8,9 @@ import { useNetwork } from '@/hooks/useNetwork';
 import { useEpochs } from '@/hooks/useRewardsEpochs';
 import { useWalletHistory } from '@/hooks/useRewardsScore';
 import { EpochRewardRow, TotalEarnedCard } from '@/components/rewards';
+import { Pagination } from '@/components/shared/Pagination.jsx';
+
+const EPOCHS_PER_PAGE = 20;
 
 export const EpochsList = () => {
   const navigate = useNavigate();
@@ -15,12 +18,14 @@ export const EpochsList = () => {
   const { isAuthenticated } = useAuth();
   const { isRobinHood } = useNetwork();
   const isRobinhoodRewardsSession = isAuthenticated && isRobinHood;
+  const [page, setPage] = React.useState(1);
 
-  const { data: epochsData, isLoading: isLoadingEpochs } = useEpochs();
+  const { data: epochsData, isLoading: isLoadingEpochs } = useEpochs(EPOCHS_PER_PAGE, (page - 1) * EPOCHS_PER_PAGE);
   const { data: historyData, isLoading: isLoadingHistory } = useWalletHistory(walletAddress);
 
-  // Data is already normalized by backend
+  // Pagination is server-side: backend returns only the current page's epochs plus the total count
   const epochs = epochsData?.epochs || [];
+  const totalPages = Math.ceil((epochsData?.total || 0) / EPOCHS_PER_PAGE);
 
   // Create a map of epoch rewards for quick lookup
   const rewardsByEpoch = React.useMemo(() => {
@@ -144,6 +149,12 @@ export const EpochsList = () => {
             return <EpochRewardRow key={epoch.id} epoch={epoch} reward={reward} score={reward?.score} />;
           })}
         </div>
+
+        {totalPages > 1 && (
+          <div className="mt-4">
+            <Pagination currentPage={page} totalPages={totalPages} onPageChange={setPage} className="justify-center" />
+          </div>
+        )}
 
         {isLoadingHistory && (
           <div className="text-center py-8">

--- a/src/services/api/rewards/index.js
+++ b/src/services/api/rewards/index.js
@@ -15,11 +15,13 @@ export class RewardsApiProvider {
   // ============================================================================
 
   /**
-   * Get all epochs
-   * @returns {Promise<Array>} List of all epochs
+   * Get paginated epochs
+   * @param {number} limit
+   * @param {number} offset
+   * @returns {Promise<{epochs: Array, total: number}>}
    */
-  static async getEpochs() {
-    const response = await axiosInstance.get(RewardsConfigProvider.epochs());
+  static async getEpochs(limit = 20, offset = 0) {
+    const response = await axiosInstance.get(RewardsConfigProvider.epochs(), { params: { limit, offset } });
     return response.data;
   }
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to support Ethereum (Robinhood) vaults alongside Cardano vaults, as well as UI and validation enhancements. The main themes are improved support for ETH vaults, consistent percentage formatting, and better UX for reward and asset displays.

**Support for Ethereum (Robinhood) vaults:**

* Added `isRobinHood` checks throughout the vault creation flow to handle ETH-specific logic, such as updating the `minAcquireThreshold` field to use ETH instead of ADA, adjusting input validation and labels, and passing `isRobinHood` to `formatVaultData` and relevant components. [[1]](diffhunk://#diff-691b675959c4129717e2094265c0721504f8735f992f444b5416e49349405fcaL600-R600) [[2]](diffhunk://#diff-691b675959c4129717e2094265c0721504f8735f992f444b5416e49349405fcaL678-R678) [[3]](diffhunk://#diff-691b675959c4129717e2094265c0721504f8735f992f444b5416e49349405fcaL743-R743) [[4]](diffhunk://#diff-3420405d9478dd6e1300c8858f5ee071a184fb15f6597f22e2bb6c47cc74446cR9) [[5]](diffhunk://#diff-3420405d9478dd6e1300c8858f5ee071a184fb15f6597f22e2bb6c47cc74446cR24-R25) [[6]](diffhunk://#diff-3420405d9478dd6e1300c8858f5ee071a184fb15f6597f22e2bb6c47cc74446cL106-R145) [[7]](diffhunk://#diff-a3ac8f2048ec81b202bb0d1cc146a9611eafdb72716ce41ef5921ae19253ae0dL13-R21)
* Updated the acquired assets list to display ETH or ADA based on network, and to hide Cardano-specific fields (Policy ID, Asset ID) for ETH vaults. [[1]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2R28) [[2]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2L205-R205) [[3]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2L224-R225) [[4]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2R242-R243) [[5]](diffhunk://#diff-23bfec7bb72ce12396e57496f7735eb2a0bbf97872b341c05fbdb2883f75e3a2R260)
* Updated initial state and comments to clarify that `minAcquireThreshold` is in ADA for Cardano and ETH for Robinhood.

**Consistent percentage formatting:**

* Introduced a `roundPercent` utility to ensure all bonus percentages in `AlignmentBonusDisplay` are consistently rounded to two decimal places. [[1]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dR28-R29) [[2]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dL48-R51) [[3]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dL58-R60) [[4]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dL69-R71) [[5]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dL81-R83) [[6]](diffhunk://#diff-f74572f2bc4f190940556d9c28a2d2526e6422855dc45740d2179e544297a06dL91-R93)

**UI/UX improvements:**

* Improved the layout of `EpochRewardRow` for better responsiveness and readability, especially on small screens. [[1]](diffhunk://#diff-ab5aca93918eb29cdadb52d5bb38a573da14a6bca0690cfc61bb697885b736b1L17-R23) [[2]](diffhunk://#diff-ab5aca93918eb29cdadb52d5bb38a573da14a6bca0690cfc61bb697885b736b1L33-R35)
* In the whitelist modal, the "Custom Price" option is now hidden for Robinhood/ETH vaults, and the custom price input is only shown when allowed. [[1]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L722-R722) [[2]](diffhunk://#diff-90d971ec36c2600e7676ac16569b09d1bb7f0115a1d11f2dc3d20c03d0d0afe1L746-R746)
* Updated the asset contribution step to use ETH as a valuation currency for Robinhood vaults and ADA for Cardano vaults. [[1]](diffhunk://#diff-691b675959c4129717e2094265c0721504f8735f992f444b5416e49349405fcaL901-R903) [[2]](diffhunk://#diff-a3ac8f2048ec81b202bb0d1cc146a9611eafdb72716ce41ef5921ae19253ae0dL13-R21)

**Validation improvements:**

* Updated validation and UI hints for `minAcquireThreshold` to be more generic (e.g., "Minimum threshold must be a number") and to support decimals for ETH. [[1]](diffhunk://#diff-206ab7ae5fd10ce2144d5799601b84cc60a42b1119b3fa9414e7adfe0534cd56L368-R371) [[2]](diffhunk://#diff-3420405d9478dd6e1300c8858f5ee071a184fb15f6597f22e2bb6c47cc74446cL106-R145)

These changes ensure the app properly supports both Cardano and Robinhood (ETH) vaults, provides a more consistent and user-friendly experience, and improves data validation where needed.