### PR TITLE
feat: show vault token details

### DIFF
--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -438,11 +438,23 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
   const renderVaultInfo = () => (
     <div className="flex justify-between items-start w-full mb-6">
       <div className="flex flex-col w-full">
-        <div className="flex w-full flex-col items-start gap-3 mb-3 sm:flex-row sm:justify-between sm:items-center">
-          <div className="flex items-center gap-2 min-w-0">
-            <h1 className="text-2xl font-bold break-words">{vault.name}</h1>
-            {vault.isOfficialPartner && (
-              <GoldenVerifiedBadge hint={OFFICIAL_PARTNER_BADGE_HINT} label="Official L4VA partner" />
+        <div className="flex w-full flex-col items-start gap-3 mb-3 sm:flex-row sm:justify-between sm:items-start">
+          <div className="flex flex-col min-w-0 gap-1">
+            <div className="flex items-center gap-2 min-w-0">
+              <h1 className="text-2xl font-bold break-words">{vault.name}</h1>
+              {vault.isOfficialPartner && (
+                <GoldenVerifiedBadge hint={OFFICIAL_PARTNER_BADGE_HINT} label="Official L4VA partner" />
+              )}
+            </div>
+            {(vault.vaultTokenTicker || vault.ftTokenSupply) && (
+              <div className="flex items-center gap-2 text-sm text-dark-100">
+                {vault.vaultTokenTicker && <span className="font-medium text-white">${vault.vaultTokenTicker}</span>}
+                {vault.ftTokenSupply ? (
+                  <span>
+                    Total Supply: <span className="text-white">{formatNum(vault.ftTokenSupply)}</span>
+                  </span>
+                ) : null}
+              </div>
             )}
           </div>
           <div className="flex gap-2 items-center">


### PR DESCRIPTION
This pull request improves the `VaultProfileView` component by enhancing how vault token information is displayed. The main change is the addition of a new section that conditionally shows the vault token ticker and total supply, making the vault profile more informative and user-friendly.

**UI improvements to vault profile:**

* Added a new section under the vault name to display the vault token ticker (`vault.vaultTokenTicker`) and total supply (`vault.ftTokenSupply`), if available. This section is styled for clarity and only appears when relevant data exists.
* Adjusted the alignment of items in the vault info header for better visual consistency, especially on small screens.