### PR TITLE
feat: add governance proposal pagination

### DIFF
--- a/src/components/vault-profile/VaultGovernance.jsx
+++ b/src/components/vault-profile/VaultGovernance.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import {
   ArrowRight,
   Check,
@@ -19,6 +19,7 @@ import { ProposalEndDate } from './ProposalEndDate';
 import { LavaTabs } from '@/components/shared/LavaTabs';
 import { LavaSelect } from '@/components/shared/LavaSelect';
 import { HoverHelp } from '@/components/shared/HoverHelp';
+import { Pagination } from '@/components/shared/Pagination';
 import L4vaIcon from '@/icons/l4va.svg?react';
 import { useDeleteProposal, useGovernanceProposals } from '@/services/api/queries';
 import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder';
@@ -26,10 +27,11 @@ import { useAuth } from '@/lib/auth/auth';
 import { useModalControls } from '@/lib/modals/modal.context';
 
 const PROPOSAL_TABS = ['All', 'Upcoming', 'Active', 'Rejected', 'Finished'];
+const PROPOSALS_PER_PAGE = 2;
 
 export const VaultGovernance = ({ vault }) => {
   const [activeTab, setActiveTab] = useState('All');
-  const [proposals, setProposals] = useState([]);
+  const [page, setPage] = useState(1);
   const [selectedProposal, setSelectedProposal] = useState(null);
   const [deletingProposalId, setDeletingProposalId] = useState(null);
   const { user } = useAuth();
@@ -43,7 +45,11 @@ export const VaultGovernance = ({ vault }) => {
     label: tab,
   }));
 
-  const { data, isLoading } = useGovernanceProposals(vault.id);
+  const { data } = useGovernanceProposals(vault.id, { page, limit: PROPOSALS_PER_PAGE });
+  const responseData = data?.data || data;
+  const proposals = Array.isArray(responseData) ? responseData : responseData?.items || [];
+  const totalPages = Array.isArray(responseData) ? 1 : responseData?.totalPages || 1;
+  const currentPage = Array.isArray(responseData) ? page : responseData?.page || page;
 
   const currentUserId = user?.id;
   const isDeleteInProgress = deleteProposalMutation.isPending || deletingProposalId !== null;
@@ -96,6 +102,12 @@ export const VaultGovernance = ({ vault }) => {
 
   const handleTabSelect = selectedTab => {
     setActiveTab(selectedTab);
+    setPage(1);
+  };
+
+  const handlePageChange = newPage => {
+    setPage(newPage);
+    window.scrollTo({ top: 0, behavior: 'smooth' });
   };
 
   const filteredProposals = proposals.filter(proposal => {
@@ -108,12 +120,6 @@ export const VaultGovernance = ({ vault }) => {
     if (activeTab === 'Finished') return proposal.status === 'executed' || proposal.status === 'passed';
     return false;
   });
-
-  useEffect(() => {
-    if (data?.data && !isLoading) {
-      setProposals(data.data);
-    }
-  }, [data, isLoading]);
 
   const handleOpenProposalInfo = proposal => {
     if (!user) {
@@ -235,7 +241,7 @@ export const VaultGovernance = ({ vault }) => {
                   inactiveTabClassName="text-dark-100"
                   tabClassName="flex-1 text-center"
                   tabs={PROPOSAL_TABS}
-                  onTabChange={setActiveTab}
+                  onTabChange={handleTabSelect}
                 />
               </div>
             </div>
@@ -428,6 +434,14 @@ export const VaultGovernance = ({ vault }) => {
                 message="No proposal found"
                 iconBgColor="bg-orange-500/15"
                 iconInnerBgColor="bg-orange-500/30"
+              />
+            )}
+            {totalPages > 1 && (
+              <Pagination
+                className="mt-6"
+                currentPage={currentPage}
+                totalPages={totalPages}
+                onPageChange={handlePageChange}
               />
             )}
           </>

--- a/src/services/api/governance/index.js
+++ b/src/services/api/governance/index.js
@@ -2,8 +2,10 @@ import { GovernanceConfigProvider } from '@/services/api/governance/config';
 import { axiosInstance } from '@/services/api';
 
 export class GovernanceApiProvider {
-  static async getProposals(vaultId) {
-    const response = await axiosInstance.get(GovernanceConfigProvider.getProposals(vaultId));
+  static async getProposals(vaultId, { page = 1, limit = 10 } = {}) {
+    const response = await axiosInstance.get(GovernanceConfigProvider.getProposals(vaultId), {
+      params: { page, limit },
+    });
     return response;
   }
 

--- a/src/services/api/queries.ts
+++ b/src/services/api/queries.ts
@@ -365,10 +365,10 @@ export const useSubmitTerminationClaim = () => {
   });
 };
 
-export const useGovernanceProposals = (vaultId: string) => {
+export const useGovernanceProposals = (vaultId: string, params: { page?: number; limit?: number } = {}) => {
   return useQuery({
-    queryKey: ['governance-proposals', vaultId],
-    queryFn: () => GovernanceApiProvider.getProposals(vaultId),
+    queryKey: ['governance-proposals', vaultId, params],
+    queryFn: () => GovernanceApiProvider.getProposals(vaultId, params),
     enabled: !!vaultId,
   });
 };


### PR DESCRIPTION
This pull request adds pagination support to the governance proposals list in the `VaultGovernance` component. It updates both the frontend and backend query logic to fetch and display proposals page by page, improving performance and user experience for vaults with many proposals.

**Pagination Feature:**

* Added a `Pagination` component to `VaultGovernance`, displaying page controls when there are multiple pages of proposals. [[1]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bR22-R34) [[2]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bR439-R446)
* Introduced `PROPOSALS_PER_PAGE` constant and page state, and updated API calls to request proposals with pagination parameters. [[1]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bR22-R34) [[2]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL46-R52)
* Implemented page change handling, resetting to page 1 when tabs change and scrolling to top on page change. [[1]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bR105-R110) [[2]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL238-R244)

**API and Query Updates:**

* Updated `GovernanceApiProvider.getProposals` to accept pagination parameters (`page`, `limit`) and pass them as request params.
* Updated `useGovernanceProposals` hook to accept and pass pagination parameters, and to include them in the query key for proper caching.

**Code Cleanup:**

* Removed unused `useEffect` and `useState` for proposals, as proposals are now derived directly from the paginated API response. [[1]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL1-R1) [[2]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL112-L117)