### PR TITLE
fix: show concise wallet errors

### DIFF
--- a/src/components/modals/LoginModal.jsx
+++ b/src/components/modals/LoginModal.jsx
@@ -108,7 +108,9 @@ export const LoginModal = () => {
           if (error?.message?.includes('already pending')) {
             toast.error('Check your wallet — a connection request is already open');
           } else {
-            toast.error(error?.message || 'Failed to connect wallet');
+            // viem's full `message` appends "Details: ...\nVersion: viem@x.y.z" —
+            // `shortMessage` is the same text without that noise.
+            toast.error(error?.shortMessage || error?.message || 'Failed to connect wallet');
           }
         },
       }


### PR DESCRIPTION
This pull request makes a small improvement to the wallet connection error handling in the `LoginModal` component. Now, when an error occurs, the code will display a cleaner error message by preferring the `shortMessage` property if available, which omits unnecessary details from the full error message.

* Improved error message display in `LoginModal` by using `error.shortMessage` when available, resulting in clearer and more user-friendly toast notifications.