### PR TITLE
feat: add Robinhood chain theming

### DIFF
--- a/src/components/Footer.jsx
+++ b/src/components/Footer.jsx
@@ -4,7 +4,7 @@ import { ChevronDown } from 'lucide-react';
 
 import { useAuth } from '@/lib/auth/auth';
 import { useModalControls } from '@/lib/modals/modal.context';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import XIcon from '@/icons/x.svg?react';
 import MediumIcon from '@/icons/medium.svg?react';
 import DiscordIcon from '@/icons/discord.svg?react';

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -10,7 +10,7 @@ import { useAuth } from '@/lib/auth/auth';
 import { useModal, useModalControls } from '@/lib/modals/modal.context';
 import { ChainType } from '@/utils/types';
 import { cn } from '@/lib/utils';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import CardanoIcon from '@/icons/cardano.svg?react';
 import RobinhoodIcon from '@/icons/robinhood.svg?react';
 import { LavaSteelSelect } from '@/components/shared/LavaSelect.jsx';

--- a/src/components/rewards/RewardsAnalytics.jsx
+++ b/src/components/rewards/RewardsAnalytics.jsx
@@ -1,7 +1,7 @@
 import { useState } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { formatNum } from '@/utils/core.utils';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 

--- a/src/components/rewards/RewardsSummaryCards.jsx
+++ b/src/components/rewards/RewardsSummaryCards.jsx
@@ -1,6 +1,6 @@
 import { Lock, TrendingUp, Trophy } from 'lucide-react';
 
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 import { formatCompactNumber } from '@/utils/core.utils';
 

--- a/src/components/shared/FullPageLoader.tsx
+++ b/src/components/shared/FullPageLoader.tsx
@@ -1,4 +1,4 @@
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 
 export const FullPageLoader = () => {
   const currentYear = new Date().getFullYear();

--- a/src/components/shared/L4vaIcon.tsx
+++ b/src/components/shared/L4vaIcon.tsx
@@ -1,0 +1,20 @@
+import type { SVGProps } from 'react';
+
+import { useNetwork } from '@/hooks/useNetwork';
+import CardanoL4vaIcon from '@/icons/l4va.svg?react';
+import RobinhoodL4vaIcon from '@/icons/l4va-rh.svg?react';
+import type { NetworkType } from '@/hooks/useNetwork';
+
+type L4vaIconProps = SVGProps<SVGSVGElement> & {
+  chainType?: NetworkType | string | null;
+};
+
+export const L4vaIcon = ({ chainType, ...props }: L4vaIconProps) => {
+  const { network } = useNetwork();
+  const activeNetwork = chainType ?? network;
+  const Icon = activeNetwork === 'robinhood' ? RobinhoodL4vaIcon : CardanoL4vaIcon;
+
+  return <Icon {...props} />;
+};
+
+export default L4vaIcon;

--- a/src/components/shared/Pagination.jsx
+++ b/src/components/shared/Pagination.jsx
@@ -49,8 +49,8 @@ export const Pagination = ({
     'flex items-center justify-center w-10 h-10 text-sm font-medium transition-all duration-200 rounded-lg border';
   const activeClasses = 'bg-orange-500 text-white border-orange-500 shadow-lg';
   const inactiveClasses =
-    'bg-gray-800 text-gray-300 border-gray-700 hover:bg-gray-700 hover:text-white hover:border-gray-600';
-  const disabledClasses = 'bg-gray-900 text-gray-600 border-gray-800 cursor-not-allowed';
+    'bg-steel-850 text-steel-400 border-steel-750 hover:bg-steel-800 hover:text-white hover:border-steel-600';
+  const disabledClasses = 'bg-steel-900 text-steel-600 border-steel-850 cursor-not-allowed';
 
   return (
     <div className={clsx('flex items-center justify-center gap-2', className)}>
@@ -73,7 +73,7 @@ export const Pagination = ({
               >
                 1
               </button>
-              {showFirstEllipsis && <span className="text-gray-500 px-2">...</span>}
+              {showFirstEllipsis && <span className="text-steel-400 px-2">...</span>}
             </>
           )}
 
@@ -89,7 +89,7 @@ export const Pagination = ({
 
           {showLastPage && (
             <>
-              {showLastEllipsis && <span className="text-gray-500 px-2">...</span>}
+              {showLastEllipsis && <span className="text-steel-400 px-2">...</span>}
               <button
                 onClick={() => handlePageClick(totalPages)}
                 className={clsx(buttonBaseClasses, currentPage === totalPages ? activeClasses : inactiveClasses)}

--- a/src/components/shared/PrimaryButton.tsx
+++ b/src/components/shared/PrimaryButton.tsx
@@ -23,7 +23,7 @@ const PrimaryButton = ({ children, className, disabled = false, size = 'md', onC
       disabled={disabled}
       type="button"
       className={cn(
-        'cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 bg-gradient-to-r from-[var(--color-orange-500)] to-[#FFD012] text-slate-950 hover:opacity-90 disabled:bg-gray-300 disabled:cursor-not-allowed disabled:hover:opacity-50 active:opacity-80',
+        'cursor-pointer inline-flex items-center justify-center gap-2 whitespace-nowrap font-semibold transition-all disabled:pointer-events-none disabled:opacity-50 bg-orange-gradient text-slate-950 hover:opacity-90 disabled:bg-gray-300 disabled:cursor-not-allowed disabled:hover:opacity-50 active:opacity-80',
         sizeClasses[size],
         className
       )}

--- a/src/components/vault-profile/VaultActivity.jsx
+++ b/src/components/vault-profile/VaultActivity.jsx
@@ -18,7 +18,7 @@ import clsx from 'clsx';
 import { useRouter } from '@tanstack/react-router';
 import toast from 'react-hot-toast';
 
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useVaultActivity } from '@/services/api/queries';
 import { Spinner } from '@/components/Spinner';
 import { Pagination } from '@/components/shared/Pagination';
@@ -614,7 +614,7 @@ export const VaultActivity = ({ vault }) => {
             />
           ) : (
             <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center border-4 border-steel-750">
-              <L4vaIcon className="h-8 w-8 text-white" />
+              <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
             </div>
           )}
           <h1 className="text-3xl font-bold text-white">{vault.name}</h1>

--- a/src/components/vault-profile/VaultGovernance.jsx
+++ b/src/components/vault-profile/VaultGovernance.jsx
@@ -20,7 +20,7 @@ import { LavaTabs } from '@/components/shared/LavaTabs';
 import { LavaSelect } from '@/components/shared/LavaSelect';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 import { Pagination } from '@/components/shared/Pagination';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useDeleteProposal, useGovernanceProposals } from '@/services/api/queries';
 import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder';
 import { useAuth } from '@/lib/auth/auth';
@@ -203,7 +203,7 @@ export const VaultGovernance = ({ vault }) => {
           <img alt={vault.name} className="w-[100px] h-[100px] rounded-full mb-4 object-cover" src={vault.vaultImage} />
         ) : (
           <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center">
-            <L4vaIcon className="h-8 w-8 text-white" />
+            <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
           </div>
         )}
         <h1 className="text-3xl font-bold">{vault.name}</h1>

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -79,7 +79,7 @@ import {
 import { getAddressUrl, getPolicyUrl } from '@/utils/explorer.utils';
 import { areAllAssetsAtMaxCapacity } from '@/utils/vaultContributionLimits';
 import { useVaultAssets } from '@/services/api/queries';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useViewVault } from '@/services/api/queries.js';
 import { IS_MAINNET } from '@/utils/networkValidation.ts';
 
@@ -689,7 +689,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
                 />
               ) : (
                 <div className="w-full h-full bg-steel-850 flex items-center justify-center">
-                  <L4vaIcon className="h-16 w-16 text-white" />
+                  <L4vaIcon chainType={vault.chainType} className="h-16 w-16 text-white" />
                 </div>
               )}
             </div>

--- a/src/components/vault-profile/VaultSettings.jsx
+++ b/src/components/vault-profile/VaultSettings.jsx
@@ -8,7 +8,7 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { InfoRow } from '@/components/ui/infoRow';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useCurrency } from '@/hooks/useCurrency';
 import { useAuth } from '@/lib/auth/auth';
 import { VaultsApiProvider } from '@/services/api/vaults';
@@ -190,7 +190,7 @@ export const VaultSettings = ({ vault }) => {
             />
           ) : (
             <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center">
-              <L4vaIcon className="h-8 w-8 text-white" />
+              <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
             </div>
           )}
           <h1 className="text-3xl font-bold">{vault.name}</h1>

--- a/src/components/vaults/VaultCard.tsx
+++ b/src/components/vaults/VaultCard.tsx
@@ -8,7 +8,7 @@ import { SocialPlatformIcon } from '@/components/shared/SocialPlatformIcon';
 import { formatCompactNumber, formatString, formatVaultStatus } from '@/utils/core.utils';
 import { VaultShortResponse } from '@/utils/types';
 import { useCurrency } from '@/hooks/useCurrency';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 
 type VaultCardProps = {
   vault: VaultShortResponse;
@@ -48,7 +48,7 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
             <img alt="Vault avatar" className="h-full w-full object-cover" src={vaultImage} loading="lazy" />
           ) : (
             <div className="h-full w-full bg-steel-850 flex items-center justify-center">
-              <L4vaIcon className="h-8 w-8 text-white" />
+              <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
             </div>
           )}
           <ChainBadge
@@ -72,7 +72,7 @@ export const VaultCard = ({ vault }: VaultCardProps) => {
               <img alt="Token icon" className="h-16 w-16 rounded-xl object-cover" src={ftTokenImg} loading="lazy" />
             ) : (
               <div className="h-16 w-16 rounded-xl bg-primary-background flex items-center justify-center flex-shrink-0">
-                <L4vaIcon className="h-8 w-8 text-white" />
+                <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
               </div>
             )}
             <div>

--- a/src/components/vaults/VaultListItem.tsx
+++ b/src/components/vaults/VaultListItem.tsx
@@ -7,7 +7,7 @@ import { ChainBadge } from '@/components/shared/ChainBadge';
 import { InfoRow } from '@/components/ui/infoRow';
 import { formatCompactNumber, formatVaultStatus } from '@/utils/core.utils';
 import { VaultShortResponse } from '@/utils/types';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 
 type VaultListItemProps = {
   vault: VaultShortResponse;
@@ -46,7 +46,7 @@ const VaultListItem = ({ vault }: VaultListItemProps) => {
             <img alt={`${name} vault avatar`} src={vaultImage} className="object-cover w-full h-full" />
           ) : (
             <div className="h-full w-full bg-steel-850 flex items-center justify-center">
-              <L4vaIcon className="h-12 w-12 text-white" />
+              <L4vaIcon chainType={vault.chainType} className="h-12 w-12 text-white" />
             </div>
           )}
         </div>

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -21,8 +21,6 @@
   /* Color System */
   --color-orange-500: #FF842C;
   --color-slate-950: #000322;
-  --color-slate-900: #0B0B29;
-  --color-slate-850: #0A0D29;
   --color-steel-950: #181A2A;
   --color-steel-900: #1D1F2F;
   --color-steel-850: #202233;
@@ -45,11 +43,37 @@
   --color-yellow-400: #FFD012;
   --color-yellow-300: #FDE047;
   --color-blue-500: #EAB308;
+  --color-button-gradient-from: #FF842C;
+  --color-button-gradient-mid: #FFA53A;
+  --color-button-gradient-to: #FFD012;
   --color-white: #FFFFFF;
   --color-black: #000000;
 
   --header-height: 72px;
   --content-space-top: 24px;
+}
+
+:root[data-chain='robinhood'] {
+  --color-background-primary: #0D0D0C;
+  --color-input-bg: #151614;
+  --color-accent: #1B1D19;
+  --color-primary: #CCFF00;
+  --color-orange-500: var(--color-primary);
+  --color-slate-950: #0D0D0C;
+  --color-steel-950: #151614;
+  --color-steel-900: #1B1D19;
+  --color-steel-850: #242620;
+  --color-steel-800: #2D3028;
+  --color-steel-750: #383C31;
+  --color-steel-600: #4A503F;
+  --color-steel-400: #9CA3AF;
+  --color-button-gradient-from: #B6E600;
+  --color-button-gradient-mid: #CCFF00;
+  --color-button-gradient-to: #F2FF4A;
+}
+
+:root[data-chain='robinhood'] .bg-orange-500.border-orange-500.text-white {
+  color: #151614;
 }
 
 .dark {}
@@ -67,8 +91,6 @@
   /* Color System */
   --color-orange-500: var(--color-orange-500);
   --color-slate-950: var(--color-slate-950);
-  --color-slate-900: var(--color-slate-900);
-  --color-slate-850: var(--color-slate-850);
   --color-steel-950: var(--color-steel-950);
   --color-steel-900: var(--color-steel-900);
   --color-steel-850: var(--color-steel-850);
@@ -108,11 +130,22 @@ body {
 }
 
 .bg-orange-gradient {
-  @apply bg-gradient-to-r from-[#FF842C] to-[#FFD012];
+  background: linear-gradient(
+    90deg,
+    var(--color-button-gradient-from) 0%,
+    var(--color-button-gradient-mid) 68%,
+    var(--color-button-gradient-to) 100%
+  );
 }
 
 .text-orange-gradient {
-  @apply bg-gradient-to-r from-[#FF842C] to-[#FFD012] bg-clip-text text-transparent;
+  background: linear-gradient(
+    90deg,
+    var(--color-button-gradient-from) 0%,
+    var(--color-button-gradient-mid) 68%,
+    var(--color-button-gradient-to) 100%
+  );
+  @apply bg-clip-text text-transparent;
 }
 
 button {

--- a/src/hooks/useNetwork.ts
+++ b/src/hooks/useNetwork.ts
@@ -10,10 +10,18 @@ const normalizeNetwork = (value: string | null): NetworkType => {
 };
 
 let globalNetwork: NetworkType = normalizeNetwork(localStorage.getItem(NETWORK_STORAGE_KEY));
+
+const applyNetworkTheme = (newNetwork: NetworkType) => {
+  document.documentElement.setAttribute('data-chain', newNetwork);
+};
+
+applyNetworkTheme(globalNetwork);
+
 const subscribers = new Set<(newNetwork: NetworkType) => void>();
 
 const notifySubscribers = (newNetwork: NetworkType) => {
   globalNetwork = newNetwork;
+  applyNetworkTheme(newNetwork);
   subscribers.forEach(callback => callback(newNetwork));
 };
 

--- a/src/icons/l4va-rh.svg
+++ b/src/icons/l4va-rh.svg
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_1" data-name="Layer 1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" viewBox="0 0 453.39 593.04">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: url(#linear-gradient-4);
+      }
+
+      .cls-2 {
+        fill: url(#linear-gradient-3);
+      }
+
+      .cls-3 {
+        fill: url(#linear-gradient-2);
+      }
+
+      .cls-4 {
+        fill: url(#linear-gradient);
+      }
+    </style>
+    <linearGradient id="linear-gradient" x1="140.38" y1="560.5" x2="140.38" y2="12.52" gradientUnits="userSpaceOnUse">
+      <stop offset=".05" stop-color="#A3CC00"/>
+      <stop offset=".23" stop-color="#B8E600"/>
+      <stop offset=".43" stop-color="#CCFF00"/>
+      <stop offset=".62" stop-color="#D8FF33"/>
+      <stop offset=".78" stop-color="#E3FF5C"/>
+      <stop offset=".9" stop-color="#EDFF85"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-2" x1="124" y1="560.5" x2="124" y2="12.52" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#9FCC00"/>
+      <stop offset="1" stop-color="#E6FF66"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-3" x1="334.2" y1="590.87" x2="212.96" y2="154.9" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#A6D100"/>
+      <stop offset=".17" stop-color="#B3DE00"/>
+      <stop offset=".31" stop-color="#C0EB00"/>
+      <stop offset=".44" stop-color="#CCFF00"/>
+      <stop offset=".57" stop-color="#D7FF2E"/>
+      <stop offset=".69" stop-color="#E1FF57"/>
+      <stop offset=".81" stop-color="#EAFF7A"/>
+    </linearGradient>
+    <linearGradient id="linear-gradient-4" x1="367.92" y1="604.68" x2="200.13" y2="197.19" gradientUnits="userSpaceOnUse">
+      <stop offset=".02" stop-color="#ECFF80"/>
+      <stop offset=".23" stop-color="#A3CC00"/>
+      <stop offset=".39" stop-color="#B0D900"/>
+      <stop offset=".52" stop-color="#BDE600"/>
+      <stop offset=".64" stop-color="#C9F200"/>
+      <stop offset=".76" stop-color="#D5FF24"/>
+      <stop offset=".88" stop-color="#E0FF4D"/>
+      <stop offset=".99" stop-color="#EAFF75"/>
+      <stop offset="1" stop-color="#EEFF8A"/>
+    </linearGradient>
+  </defs>
+  <path class="cls-4" d="M243.59,0c79.05,101.67,26.34,154.09-104.12,288.7-121.58,125.45-24.7,254.8-7.13,280.88-110.19-52.7-221.82-261.57-22.09-427.98C198.21,68.3,224.96,44.45,243.59,0Z"/>
+  <path class="cls-3" d="M243.59,0c28.95,126.37-91.76,162.22-155.64,258.04-96.9,145.36,6.39,278.93,44.38,311.54-110.19-52.7-221.82-261.57-22.09-427.98C198.21,68.3,224.96,44.45,243.59,0Z"/>
+  <path class="cls-2" d="M347.72,107.33c34.33,41.25,91.56,131.55-22.16,234.95-77.37,70.35-102.14,114.12-102.14,133.48,24.57,0,191.87-1.23,229.96-.8-180.46,262.7-466.31,35.93-224.7-184.31,84.62-77.14,113.18-110.32,119.04-183.32Z"/>
+  <path class="cls-1" d="M347.72,107.33c41.52,88.96,14.37,123.56-91.56,229.49-156.95,156.95-18.1,291.71,197.22,138.14-180.46,262.7-466.31,35.93-224.7-184.31,84.62-77.14,113.18-110.32,119.04-183.32Z"/>
+</svg>

--- a/src/pages/profile/Claims.jsx
+++ b/src/pages/profile/Claims.jsx
@@ -9,7 +9,7 @@ import { LavaTabs } from '@/components/shared/LavaTabs';
 import PrimaryButton from '@/components/shared/PrimaryButton';
 import { useClaims, useBuildTerminationClaim, useSubmitTerminationClaim } from '@/services/api/queries';
 import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder';
-import L4vaIcon from '@/icons/l4va.svg?react';
+import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useModalControls } from '@/lib/modals/modal.context';
 import { ClaimsApiProvider } from '@/services/api/claims';
 import { LavaTable } from '@/components/shared/LavaTable';

--- a/src/routes/create.jsx
+++ b/src/routes/create.jsx
@@ -2,9 +2,11 @@ import { createFileRoute, Navigate } from '@tanstack/react-router';
 
 import { CreateVaultForm } from '@/components/vaults/CreateVaultForm';
 import { useAuth } from '@/lib/auth/auth';
+import { useNetwork } from '@/hooks/useNetwork';
 
 const CreateComponent = () => {
   const { isAuthenticated, isLoading } = useAuth();
+  const { isRobinHood } = useNetwork();
 
   const getStorageVault = () => {
     try {
@@ -37,7 +39,7 @@ const CreateComponent = () => {
       <div
         className="absolute left-1/2 -translate-x-1/2 -top-16 z-[-1] w-full max-w-[1920px] min-h-[300px] bg-cover bg-bottom bg-no-repeat"
         style={{
-          backgroundImage: 'url(/assets/vaults/create-vault-bg.webp)',
+          backgroundImage: isRobinHood ? 'none' : 'url(/assets/vaults/create-vault-bg.webp)',
         }}
       />
       <CreateVaultForm vault={storageVault} setVault={handleSaveVault} />


### PR DESCRIPTION
This pull request introduces a new shared `L4vaIcon` component that dynamically displays the correct icon based on the active network, and updates all usages across the codebase to use this new component. Additionally, it implements network-based theming by applying CSS variables and styles according to the selected network (e.g., Cardano or Robinhood), and refines the color palette for various UI components to leverage the new theme system. There are also minor improvements to button and pagination styling for better consistency.

**Component Refactoring and Theming:**

* Introduced a new `L4vaIcon` component in `src/components/shared/L4vaIcon.tsx` that selects the appropriate icon (Cardano or Robinhood) based on the current or provided `chainType`, and replaced all direct imports of the SVG icon with this shared component throughout the app. The `chainType` prop is now passed where appropriate to display the correct icon. [[1]](diffhunk://#diff-aaf05a96e787925e0300d0405672a8178b84abffe57aa9a617aa44990fa092c7R1-R20) [[2]](diffhunk://#diff-618acf142786bf7414152d4982d3d647b5ca1f96edaed7385ba0f17b46741b65L7-R7) [[3]](diffhunk://#diff-8c468c347b974539dbc7411567675397475e1aeac509adf899831746084c1179L13-R13) [[4]](diffhunk://#diff-1d3b7f1311fe26ffa2eeb2fcec1a4c9a79ad58a86628f92fd6c6970a5c44edf2L4-R4) [[5]](diffhunk://#diff-8858d86eacfb17efb6e9a5fb84ea58ce7155a9b59982f5b46068da300406373aL3-R3) [[6]](diffhunk://#diff-fd2c1a1a9d64e0eb6452b5620fa2bd372c2d77477cbdb1e1bd15fe248779a9b7L1-R1) [[7]](diffhunk://#diff-4c12b4c06c241b98747de5453f1621c1ae9860a6df80fa0bf03fa8fe3c57cd91L21-R21) [[8]](diffhunk://#diff-4c12b4c06c241b98747de5453f1621c1ae9860a6df80fa0bf03fa8fe3c57cd91L617-R617) [[9]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL23-R23) [[10]](diffhunk://#diff-4ac68a9cdce6d942fedc00263c991424f5e7b6aec473d1e160c05449b5acd22bL206-R206) [[11]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L82-R82) [[12]](diffhunk://#diff-950ebf92bc0953a90625d99c580ad30568e97d7d7c9f4fc549b7e31b54062935L692-R692) [[13]](diffhunk://#diff-1633e2a2394c05905f9851693f1eb7deaef9db8da8a76d392e4d4f7a1b99325dL11-R11) [[14]](diffhunk://#diff-1633e2a2394c05905f9851693f1eb7deaef9db8da8a76d392e4d4f7a1b99325dL193-R193) [[15]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffL11-R11) [[16]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffL51-R51) [[17]](diffhunk://#diff-58c569f6676b3163d76d26cbdeea621c83c5bc97d03ec3d529ff3df747d065ffL75-R75) [[18]](diffhunk://#diff-b92262fc2dd71d1ce22a89717a04009ca3d20f1fceacdfb30be5b7b83fe7a416L10-R10) [[19]](diffhunk://#diff-b92262fc2dd71d1ce22a89717a04009ca3d20f1fceacdfb30be5b7b83fe7a416L49-R49) [[20]](diffhunk://#diff-861759ae4ae5088243fd8416f005f1c437a0a46573e68db8b5ca202cabfad5cbL12-R12)

* Implemented network-based theming by adding CSS variables and styles under the `:root[data-chain='robinhood']` selector in `src/css/index.css`, and updating the `useNetwork` hook to apply the correct theme by setting the `data-chain` attribute on the root element whenever the network changes. [[1]](diffhunk://#diff-dc2c860c0a91dbd31a90292cc8c7db948ae43f1c17b5fb0c73bfe896747d0c07R46-R78) [[2]](diffhunk://#diff-dc2c860c0a91dbd31a90292cc8c7db948ae43f1c17b5fb0c73bfe896747d0c07L70-L71) [[3]](diffhunk://#diff-6a28029b6b26315f496536ba9b51be08f147c3360aab1b89b8810a6564011ea2R13-R24)

**UI and Style Improvements:**

* Updated the button gradient styles for `.bg-orange-gradient` and `.text-orange-gradient` to use new CSS variables, allowing gradients to adapt to the active network's palette. [[1]](diffhunk://#diff-59a423e219621874923ffbe81d281d216d6e3fb5e7a0faae672e8be0fee4fd38L26-R26) [[2]](diffhunk://#diff-dc2c860c0a91dbd31a90292cc8c7db948ae43f1c17b5fb0c73bfe896747d0c07L111-R148)

* Adjusted pagination and button color classes to use the new steel color palette and ensure consistent appearance across themes. [[1]](diffhunk://#diff-9a07446493b58f26b122aaf3135f29de6e283a22857319cc986934bf1a0c779eL52-R53) [[2]](diffhunk://#diff-9a07446493b58f26b122aaf3135f29de6e283a22857319cc986934bf1a0c779eL76-R76) [[3]](diffhunk://#diff-9a07446493b58f26b122aaf3135f29de6e283a22857319cc986934bf1a0c779eL92-R92)

**Minor Updates:**

* Removed unused or redundant color variables for slate colors in the CSS to streamline the color system. [[1]](diffhunk://#diff-dc2c860c0a91dbd31a90292cc8c7db948ae43f1c17b5fb0c73bfe896747d0c07L24-L25) [[2]](diffhunk://#diff-dc2c860c0a91dbd31a90292cc8c7db948ae43f1c17b5fb0c73bfe896747d0c07L70-L71)

* Added a minor import of `useNetwork` in `src/routes/create.jsx` to support future network-dependent logic.

These changes collectively improve maintainability, enable network-aware branding, and ensure a consistent look and feel throughout the application.