### PR TITLE
fix: show initial whitelist asset row

### DIFF
--- a/src/components/vaults/CreateVaultForm.jsx
+++ b/src/components/vaults/CreateVaultForm.jsx
@@ -35,6 +35,7 @@ import {
 import { isStepFullyComplete } from '@/utils/stepValidation';
 import {
   CREATE_VAULT_STEPS,
+  createEmptyWhitelistAsset,
   initialVaultState,
   stepFields,
   VAULT_PRIVACY_TYPES,
@@ -166,7 +167,12 @@ export const CreateVaultForm = ({ vault, setVault }) => {
 
   useEffect(() => {
     if (vault) {
-      setVaultData(vault);
+      setVaultData({
+        ...vault,
+        // A draft saved before any assets were added would otherwise leave the
+        // asset table hidden behind an empty array, same as a brand new vault.
+        assetsWhitelist: vault.assetsWhitelist?.length ? vault.assetsWhitelist : [createEmptyWhitelistAsset()],
+      });
       isPresetManuallyChanged.current = false;
       // Allow the preset resolution effect to re-run for the new vault
       resolvedForVaultRef.current = null;

--- a/src/components/vaults/constants/vaults.constants.js
+++ b/src/components/vaults/constants/vaults.constants.js
@@ -607,6 +607,24 @@ export const editUpcomingVaultSchema = yup.object({
   tags: yup.array().of(yup.string()).default([]),
 });
 
+// Matches the shape LavaWhitelistWithCaps.addNewAsset() creates, so the asset
+// table (header + row) is visible as soon as the create flow loads instead of
+// showing only the "+" button until the user adds a row themselves.
+export const createEmptyWhitelistAsset = () => ({
+  policyId: '',
+  assetName: '',
+  name: '',
+  count: 1,
+  policyName: 'N/A',
+  collectionName: null,
+  isVerified: null,
+  verificationPlatform: null,
+  valuationMethod: 'market',
+  customPriceAda: null,
+  countCapMin: 1,
+  countCapMax: 1000,
+});
+
 export const initialVaultState = {
   // Step 1: Configure Vault
   name: '',
@@ -628,7 +646,7 @@ export const initialVaultState = {
   contributionOpenWindowType: 'upon-vault-launch',
   contributionOpenWindowTime: null,
   contributionDuration: MIN_CONTRIBUTION_DURATION_MS,
-  assetsWhitelist: [],
+  assetsWhitelist: [createEmptyWhitelistAsset()],
   valuationCurrency: 'ADA',
   valuationAmount: null,
 


### PR DESCRIPTION
This pull request improves the user experience in the vault creation flow by ensuring that the asset whitelist table is always visible when creating or editing a vault, even if no assets have been added yet. This is achieved by automatically initializing the `assetsWhitelist` with a default empty asset row, preventing the table from being hidden behind an empty array.

Enhancements to vault asset whitelist initialization:

* Added a `createEmptyWhitelistAsset` utility function that returns a default asset object, matching the shape expected by the asset table. This ensures the table (header + row) is visible as soon as the create flow loads.
* Updated `initialVaultState` to initialize `assetsWhitelist` with a default empty asset row instead of an empty array.
* Modified the `CreateVaultForm` component to ensure that when loading a saved draft vault with an empty or missing `assetsWhitelist`, the form initializes with a default row for better user guidance.
* Imported the new `createEmptyWhitelistAsset` function where needed in `CreateVaultForm.jsx`.