### PR TITLE
UI fix

### DIFF
--- a/src/components/rewards/EpochRewardRow.jsx
+++ b/src/components/rewards/EpochRewardRow.jsx
@@ -11,7 +11,7 @@ export const EpochRewardRow = ({ epoch, reward = null, score = null, onClick = n
 
   return (
     <div
-      className={`p-4 bg-gray-800/50 border border-gray-700/50 rounded-lg hover:bg-gray-800/70 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
+      className={`p-4 bg-steel-800/50 border border-gray-700/50 rounded-lg hover:bg-steel-800/70 transition-colors ${onClick ? 'cursor-pointer' : ''}`}
       onClick={onClick}
     >
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3">

--- a/src/components/rewards/EpochSelector.jsx
+++ b/src/components/rewards/EpochSelector.jsx
@@ -54,7 +54,7 @@ export const EpochSelector = ({ selectedEpochIds = [], onChange, mode = 'single'
   };
 
   if (isLoading) {
-    return <div className="h-10 w-40 bg-gray-800/50 rounded-lg animate-pulse" />;
+    return <div className="h-10 w-40 bg-steel-800/50 rounded-lg animate-pulse" />;
   }
 
   return (

--- a/src/components/rewards/TotalEarnedCard.jsx
+++ b/src/components/rewards/TotalEarnedCard.jsx
@@ -7,7 +7,7 @@ export const TotalEarnedCard = ({
   showIcon = true,
   label = 'Total Earned',
   labelClassName = 'text-steel-400 text-xs font-medium uppercase tracking-wide',
-  valueClassName = 'text-xl font-bold text-orange-400',
+  valueClassName = 'text-xl font-bold text-orange-gradient',
 }) => {
   return (
     <div className={`bg-steel-850 border border-steel-750 rounded-2xl p-5 ${className}`.trim()}>

--- a/src/components/rewards/VaultLeaderboard.jsx
+++ b/src/components/rewards/VaultLeaderboard.jsx
@@ -23,7 +23,7 @@ export const VaultLeaderboard = ({ scores = [], currentWalletAddress = null }) =
           <div
             key={entry.walletAddress || index}
             className={`p-3 rounded-lg flex items-center gap-4 ${
-              isCurrentWallet ? 'bg-blue-500/20 border border-blue-500/30' : 'bg-gray-800/50'
+              isCurrentWallet ? 'bg-steel-500/20 border border-blue-500/30' : 'bg-steel-800/50'
             }`}
           >
             {/* Rank */}

--- a/src/components/rewards/VestingGrouped.jsx
+++ b/src/components/rewards/VestingGrouped.jsx
@@ -77,7 +77,7 @@ export const VestingGrouped = ({ positions, groupBy = 'epoch' }) => {
             {/* Group Header */}
             <button
               onClick={() => toggleGroup(key)}
-              className="w-full px-4 py-3 bg-gray-800/30 hover:bg-gray-800/50 transition-colors flex items-center justify-between"
+              className="w-full px-4 py-3 bg-steel-800/30 hover:bg-steel-800/50 transition-colors flex items-center justify-between"
             >
               <div className="flex items-center gap-3">
                 <span className="font-semibold text-white">{group.label}</span>

--- a/src/components/rewards/VestingProgress.jsx
+++ b/src/components/rewards/VestingProgress.jsx
@@ -28,7 +28,7 @@ export const VestingProgress = ({ position }) => {
   const statusColor = isCompleted ? statusColors.completed : isExpired ? statusColors.expired : statusColors.active;
 
   return (
-    <div className="p-4 bg-gray-800/50 border border-gray-700/50 rounded-lg">
+    <div className="p-4 bg-steel-800/50 border border-gray-700/50 rounded-lg">
       <div className="flex items-start justify-between mb-4">
         <div className="flex-1">
           <div className="flex items-center gap-2 mb-2">

--- a/src/components/vault-profile/VaultContributedAssetsCard.jsx
+++ b/src/components/vault-profile/VaultContributedAssetsCard.jsx
@@ -3,6 +3,7 @@ import toast from 'react-hot-toast';
 import { useState } from 'react';
 
 import { substringAddress, formatAdaPrice, formatNum } from '@/utils/core.utils.js';
+import { TokenImage } from '@/components/shared/TokenImage.jsx';
 
 const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda, isRobinhoodVault }) => {
   const policyLabel = isRobinhoodVault ? 'Contract' : 'Policy ID';
@@ -13,7 +14,6 @@ const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda, isRobinh
     toast.success(message);
   };
 
-  const imageUrl = asset.image ? asset.image : '/assets/icons/ada.svg';
   const assetName = asset.name || (asset.assetId === 'lovelace' ? 'ADA' : substringAddress(asset.assetId));
 
   return (
@@ -29,7 +29,14 @@ const AssetCard = ({ asset, isExpanded, onClick, currencySymbol, isAda, isRobinh
         onClick={onClick}
       >
         <div className="flex items-center gap-3 overflow-hidden">
-          <img alt={assetName} className="w-12 h-12 rounded-lg object-cover flex-shrink-0" src={imageUrl} />
+          <TokenImage
+            asset={asset}
+            alt={assetName}
+            className="rounded-lg flex-shrink-0"
+            width={48}
+            height={48}
+            chainType={isRobinhoodVault ? 'robinhood' : 'cardano'}
+          />
           <p className="font-medium text-white truncate">{assetName}</p>
         </div>
 

--- a/src/components/vault-profile/VaultContributedAssetsList.jsx
+++ b/src/components/vault-profile/VaultContributedAssetsList.jsx
@@ -8,9 +8,8 @@ import { substringAddress, formatAdaPrice, formatNumber, formatLargeNumber, form
 import { VaultContributedAssetsCard } from '@/components/vault-profile/VaultContributedAssetsCard.jsx';
 import { LavaSearchInput } from '@/components/shared/LavaInput.jsx';
 import { LavaSelect, LavaMultiSelect } from '@/components/shared/LavaSelect';
+import { TokenImage } from '@/components/shared/TokenImage.jsx';
 import { useCurrency } from '@/hooks/useCurrency';
-
-const FALLBACK_IMAGE = '/assets/icons/ada.svg';
 
 const StatBadge = ({ icon: Icon, label, value }) => (
   <div className="flex items-center gap-3 px-4 py-3 rounded-xl border border-steel-800 w-full md:w-auto">
@@ -212,13 +211,13 @@ const VaultContributedAssetsList = ({ vault }) => {
                         onClick={() => setExpandedAsset(expandedAsset === index ? null : index)}
                       >
                         <td className="px-4 py-3">
-                          <img
+                          <TokenImage
+                            asset={asset}
                             alt={asset.name || 'NFT'}
-                            className="w-12 h-12 rounded-lg object-cover"
-                            src={asset.image || FALLBACK_IMAGE}
-                            onError={e => {
-                              e.target.src = FALLBACK_IMAGE;
-                            }}
+                            className="rounded-lg"
+                            width={48}
+                            height={48}
+                            chainType={isRobinhoodVault ? 'robinhood' : 'cardano'}
                           />
                         </td>
                         <td

--- a/src/pages/rewards/RewardsOverview.jsx
+++ b/src/pages/rewards/RewardsOverview.jsx
@@ -141,7 +141,7 @@ export const RewardsOverview = () => {
             <h1 className="text-3xl font-bold text-white">Rewards Dashboard</h1>
             <button
               onClick={() => setIsInfoModalOpen(true)}
-              className="p-2 rounded-lg bg-orange-500/10 hover:bg-orange-500/20 text-orange-400 transition-colors"
+              className="p-2 rounded-lg bg-orange-500/10 hover:bg-orange-500/20 text-orange-500 transition-colors"
               aria-label="How rewards work"
             >
               <Info className="w-5 h-5" />


### PR DESCRIPTION
This pull request focuses on visual consistency and improved asset image handling across several components in the rewards and vault profile sections. The main changes include standardizing background color classes to use the `steel` palette instead of `gray`, updating text color styles, and refactoring asset image rendering to use a shared `TokenImage` component for better reliability and code reuse.

**Visual consistency improvements:**

* Replaced various `bg-gray-800` and related background classes with `bg-steel-800` or `bg-steel-850` in rewards-related components, including `EpochRewardRow`, `EpochSelector`, `VaultLeaderboard`, `VestingGrouped`, and `VestingProgress`, to unify the color palette. [[1]](diffhunk://#diff-ab5aca93918eb29cdadb52d5bb38a573da14a6bca0690cfc61bb697885b736b1L14-R14) [[2]](diffhunk://#diff-aca319fe568a33d3e22080ee7e05f19f8d679f2c69b70ca6413b5344e7548406L57-R57) [[3]](diffhunk://#diff-00723c0359376fed594a72ade93eb7125b657d9514c922ac1d74c3e0353e5691L26-R26) [[4]](diffhunk://#diff-bb7ee658db4ec7cf2b54bf6dac0b9af0e0e76458303472f50d0f265a8e13290dL80-R80) [[5]](diffhunk://#diff-02baba8eeba873d2baf2b0d635db9487d6551ed9a0239bf00a5fa0bd061deb2aL31-R31)
* Updated the value text color in `TotalEarnedCard` from `text-orange-400` to `text-orange-gradient` for a more visually appealing display.
* Changed the info button text color in `RewardsOverview` from `text-orange-400` to `text-orange-500` for consistency.

**Asset image rendering improvements:**

* Replaced direct `<img>` tags with the shared `TokenImage` component in both `VaultContributedAssetsCard` and `VaultContributedAssetsList`, ensuring consistent image sizing, fallback handling, and chain type support. This also removes the need for manual fallback logic. [[1]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaR6) [[2]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL16) [[3]](diffhunk://#diff-55d63bac8b4952e7648b4ef5ae29ab78649defdbd612ab690d964403f1d6bfdaL32-R39) [[4]](diffhunk://#diff-3860b1eacae73613e77bfdbaa4d5b6668e99a50bb0dd0286435301ed4c77820fR11-L14) [[5]](diffhunk://#diff-3860b1eacae73613e77bfdbaa4d5b6668e99a50bb0dd0286435301ed4c77820fL215-R220)