### PR TITLE
Enhance EVM support and improve proposal components and UI

### DIFF
--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -7,9 +7,11 @@ import { LavaCheckbox } from '@/components/shared/LavaCheckbox';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 import { MIN_EXPANSION_DURATION_MS } from '@/components/vaults/constants/vaults.constants';
 import { useCurrency } from '@/hooks/useCurrency';
+import { ChainType } from '@/utils/types';
 
 export default function AcquireExpansion({ onDataChange, error, vault }) {
   const { currencyLabel } = useCurrency();
+  const isEvmVault = vault?.chainType === ChainType.ROBINHOOD;
   const [duration, setDuration] = useState(null);
   const [noLimit, setNoLimit] = useState(false);
   const [maxAda, setMaxAda] = useState('');
@@ -236,26 +238,30 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
                   <strong>Market Price Calculation:</strong>
                 </p>
                 <p className="text-sm text-gray-300">
-                  Contributors will receive VT based on the current market price from the Liquidity Pool:
+                  Contributors will receive VT based on the current market price
+                  {isEvmVault ? ' from Uniswap' : ' from the Liquidity Pool'}:
                 </p>
                 <div className="p-3 bg-steel-800 rounded font-mono text-sm text-primary">
-                  VT Amount = {currencyLabel} Sent x (Current VT/{currencyLabel} Price from LP)
+                  VT Amount = {currencyLabel} Sent x (Current VT/{currencyLabel} Price from{' '}
+                  {isEvmVault ? 'Uniswap' : 'LP'})
                 </div>
                 <p className="text-xs text-gray-400">
-                  This ensures contributors receive VT at fair market value based on DEX prices (DexHunter, Taptools)
+                  {isEvmVault
+                    ? `VT price is fetched from the Uniswap pool on Robinhood Chain at cycle close time`
+                    : `This ensures contributors receive VT at fair market value based on DEX prices (DexHunter, Taptools)`}
                 </p>
               </div>
               {!vault?.hasActiveLp && (
                 <div className="p-3 bg-yellow-900/20 border border-yellow-600/50 rounded-lg">
                   <p className="text-yellow-400 text-sm font-medium">⚠️ Market Pricing Requirements:</p>
                   <p className="text-yellow-300/90 text-xs mt-1">
-                    This vault does not have an active Liquidity Pool on DEXes. Market pricing requires an active LP
-                    with at least 1,000 {currencyLabel} in liquidity. Please use <strong>Limit Price</strong> instead,
-                    or create an LP first.
+                    {isEvmVault
+                      ? `This vault does not have an active Uniswap pool. Market pricing requires a VT pool with liquidity. Please use Limit Price instead.`
+                      : `This vault does not have an active Liquidity Pool on DEXes. Market pricing requires an active LP with at least 1,000 ${currencyLabel} in liquidity. Please use Limit Price instead, or create an LP first.`}
                   </p>
                 </div>
               )}
-              {vault?.hasActiveLp && vault?.vtPrice && (
+              {!isEvmVault && vault?.hasActiveLp && vault?.vtPrice && (
                 <div className="p-3 bg-primary/10 border border-primary/30 rounded-lg">
                   <p className="text-primary text-sm font-medium">✓ LP Detected</p>
                   <p className="text-gray-300 text-xs mt-1">Current VT Price: {vault.vtPrice.toFixed(6)} ₳ per VT</p>

--- a/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
+++ b/src/components/modals/CreateProposalModal/AcquireExpansion.jsx
@@ -12,6 +12,7 @@ import { ChainType } from '@/utils/types';
 export default function AcquireExpansion({ onDataChange, error, vault }) {
   const { currencyLabel } = useCurrency();
   const isEvmVault = vault?.chainType === ChainType.ROBINHOOD;
+  const exampleContributionAmount = isEvmVault ? 1 : 100;
   const [duration, setDuration] = useState(null);
   const [noLimit, setNoLimit] = useState(false);
   const [maxAda, setMaxAda] = useState('');
@@ -217,7 +218,8 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
                     <div className="mt-2 p-3 bg-steel-800 rounded">
                       <p className="text-xs text-gray-400">Example calculation:</p>
                       <p className="text-sm text-primary font-mono mt-1">
-                        100 ₳ = {(limitPriceNum * 100).toLocaleString()} VT
+                        {exampleContributionAmount} {currencyLabel} ={' '}
+                        {(limitPriceNum * exampleContributionAmount).toLocaleString()} VT
                       </p>
                       <p className="text-xs text-gray-500 mt-1">
                         Min: {minLimitPrice} VT/{currencyLabel}
@@ -261,12 +263,15 @@ export default function AcquireExpansion({ onDataChange, error, vault }) {
                   </p>
                 </div>
               )}
-              {!isEvmVault && vault?.hasActiveLp && vault?.vtPrice && (
+              {vault?.hasActiveLp && vault?.vtPrice && (
                 <div className="p-3 bg-primary/10 border border-primary/30 rounded-lg">
-                  <p className="text-primary text-sm font-medium">✓ LP Detected</p>
-                  <p className="text-gray-300 text-xs mt-1">Current VT Price: {vault.vtPrice.toFixed(6)} ₳ per VT</p>
+                  <p className="text-primary text-sm font-medium">✓ {isEvmVault ? 'Uniswap Pool' : 'LP'} Detected</p>
+                  <p className="text-gray-300 text-xs mt-1">
+                    Current VT Price: {vault.vtPrice.toFixed(6)} {currencyLabel} per VT
+                  </p>
                   <p className="text-gray-400 text-xs mt-1">
-                    Example: 100 ₳ = ~{(100 / vault.vtPrice).toFixed(2)} VT (at current price)
+                    Example: {exampleContributionAmount} {currencyLabel} = ~
+                    {(exampleContributionAmount / vault.vtPrice).toFixed(2)} VT (at current price)
                   </p>
                 </div>
               )}

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -223,7 +223,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
             expectedOutputAsset: action.outputAsset,
             amount: action.amount,
             market: 'Uniswap',
-            assetId: action.inputAsset,
+            assetId: '',
           }));
           // EVM: close position proposal
         } else if (marketActionType === 'evm_close_position') {

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useState, useMemo } from 'react';
 import toast from 'react-hot-toast';
 import { useWallet } from '@ada-anvil/weld/react';
+import { useAccount } from 'wagmi';
 
 import Staking from '@/components/modals/CreateProposalModal/Staking';
 import Distributing from '@/components/modals/CreateProposalModal/Distributing';
@@ -52,8 +53,6 @@ const evmExecutionOptions = [
   { value: 'termination', label: 'Termination' },
 ];
 
-const executionOptions = cardanoExecutionOptions;
-
 const initialProposalData = {
   isValid: true,
 };
@@ -75,10 +74,14 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   const [status, setStatus] = useState('idle');
 
   const wallet = useWallet('handler', 'isConnected');
+  const { isConnected: isEvmConnected } = useAccount();
   const createProposalMutation = useCreateProposal();
   const submitProposalFeePayment = useSubmitProposalFeePayment();
   const deleteProposalMutation = useDeleteProposal();
   const { data: governanceFees } = useGovernanceFees();
+
+  const isWalletConnected = isEvmVault ? isEvmConnected : wallet.isConnected;
+  const connectWalletLabel = isEvmVault ? 'Robinhood wallet' : 'Cardano wallet';
 
   const { refetch } = useGovernanceProposals(vault.id);
 
@@ -121,6 +124,11 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   }, [vault.vaultStatus, activeExecutionOptions]);
 
   const handleCreateProposal = () => {
+    if (!isWalletConnected) {
+      toast.error(`Please connect your ${connectWalletLabel} first`);
+      return;
+    }
+
     // Validate voting duration constraints
     if (proposalDuration && (proposalDuration < MIN_TIME_FOR_VOTING || proposalDuration > MAX_TIME_FOR_VOTING)) {
       const minHours = MIN_TIME_FOR_VOTING / (1000 * 60 * 60);
@@ -158,8 +166,8 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
     setStatus('creating');
     try {
       // Step 1: Check if wallet is connected
-      if (!wallet.isConnected || !wallet.handler) {
-        toast.error('Please connect your wallet first');
+      if (!isWalletConnected) {
+        toast.error(`Please connect your ${connectWalletLabel} first`);
         setStatus('idle');
         return;
       }
@@ -293,6 +301,10 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       // Step 4: Handle payment if required
       if (requiresPayment && presignedTx) {
         try {
+          if (!wallet.handler) {
+            throw new Error('Cardano wallet is required to sign the proposal fee transaction');
+          }
+
           // Sign fee transaction
           setStatus('signing');
           const signature = await wallet.handler.signTx(presignedTx, true);
@@ -381,7 +393,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   }, []);
 
   const handleChangeExecutionOption = value => {
-    const option = executionOptions.find(opt => opt.value === value);
+    const option = availableExecutionOptions.find(opt => opt.value === value);
     if (option?.disabled) {
       return;
     }
@@ -486,7 +498,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
             )}
             {selectedOption === 'distribution' && (
               <Distributing
-                isDisabled={executionOptions.find(opt => opt.value === 'distribution')?.disabled}
+                isDisabled={availableExecutionOptions.find(opt => opt.value === 'distribution')?.disabled}
                 vaultId={vault?.id}
                 onDataChange={handleDataChange}
               />

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -49,6 +49,8 @@ const cardanoExecutionOptions = [
 
 const evmExecutionOptions = [
   { value: 'marketplace_action', label: 'Market Actions (Swap / Close Position)' },
+  { value: 'expansion', label: 'Vault Expansion' },
+  { value: 'acquire_expansion', label: 'Acquire Expansion' },
   { value: 'distribution', label: 'Distribution' },
   { value: 'termination', label: 'Termination' },
 ];
@@ -187,7 +189,11 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       } else if (selectedOption === 'distribution') {
         proposalPayload.distributionLovelaceAmount = proposalData.distributionLovelaceAmount;
       } else if (selectedOption === 'expansion') {
-        proposalPayload.expansionPolicyIds = proposalData.expansionPolicyIds || [];
+        if (isEvmVault) {
+          proposalPayload.expansionEvmAssets = proposalData.expansionEvmAssets || [];
+        } else {
+          proposalPayload.expansionPolicyIds = proposalData.expansionPolicyIds || [];
+        }
         proposalPayload.expansionDuration = proposalData.expansionDuration;
         proposalPayload.expansionNoLimit = proposalData.expansionNoLimit || false;
         proposalPayload.expansionAssetMax = proposalData.expansionAssetMax;

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -222,6 +222,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
             inputAsset: action.inputAsset,
             expectedOutputAsset: action.outputAsset,
             amount: action.amount,
+            humanAmount: action.humanAmount,
             market: 'Uniswap',
             assetId: '',
           }));

--- a/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
+++ b/src/components/modals/CreateProposalModal/CreateProposalModal.jsx
@@ -32,8 +32,9 @@ import { LavaDatePicker } from '@/components/shared/LavaDatePicker.jsx';
 import { MarketActions } from '@/components/modals/CreateProposalModal/MarketActions/MarketActions.jsx';
 import AssetWhitelistUpdate from '@/components/modals/CreateProposalModal/AssetWhitelistUpdate.jsx';
 import { useCurrency } from '@/hooks/useCurrency';
+import { ChainType } from '@/utils/types';
 
-const executionOptions = [
+const cardanoExecutionOptions = [
   { value: 'marketplace_action', label: 'Market Actions' },
   { value: 'expansion', label: 'Vault Expansion' },
   { value: 'asset_whitelist_update', label: 'Update Asset Whitelist' },
@@ -45,12 +46,22 @@ const executionOptions = [
   { value: 'add_remove_lp', label: 'Add/Remove LP - Coming Soon', disabled: true },
 ];
 
+const evmExecutionOptions = [
+  { value: 'marketplace_action', label: 'Market Actions (Swap / Close Position)' },
+  { value: 'distribution', label: 'Distribution' },
+  { value: 'termination', label: 'Termination' },
+];
+
+const executionOptions = cardanoExecutionOptions;
+
 const initialProposalData = {
   isValid: true,
 };
 
 export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
   const { currencyLabel } = useCurrency();
+  const isEvmVault = vault?.chainType === ChainType.ROBINHOOD;
+  const activeExecutionOptions = isEvmVault ? evmExecutionOptions : cardanoExecutionOptions;
   const [proposalTitle, setProposalTitle] = useState('');
   const [proposalDescription, setProposalDescription] = useState('');
   const [selectedOption, setSelectedOption] = useState(
@@ -94,7 +105,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       vault.vaultStatus === VAULT_STATUSES.EXPANSION || vault.vaultStatus === VAULT_STATUSES.ACQUIRE_EXPANSION;
 
     if (isExpansion) {
-      return executionOptions.map(option => {
+      return activeExecutionOptions.map(option => {
         if (option.value === 'distribution') {
           return option;
         }
@@ -106,8 +117,8 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       });
     }
 
-    return executionOptions;
-  }, [vault.vaultStatus]);
+    return activeExecutionOptions;
+  }, [vault.vaultStatus, activeExecutionOptions]);
 
   const handleCreateProposal = () => {
     // Validate voting duration constraints
@@ -196,7 +207,31 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
       } else if (selectedOption === 'marketplace_action') {
         const marketActionType = proposalData.marketActionType || 'buy';
 
-        if (marketActionType === 'swap') {
+        // EVM: Uniswap swap proposal
+        if (marketActionType === 'evm_swap') {
+          proposalPayload.marketplaceActions = (proposalData.evmSwapActions || []).map(action => ({
+            exec: 'SELL',
+            inputAsset: action.inputAsset,
+            expectedOutputAsset: action.outputAsset,
+            amount: action.amount,
+            market: 'Uniswap',
+            assetId: action.inputAsset,
+          }));
+          // EVM: close position proposal
+        } else if (marketActionType === 'evm_close_position') {
+          const a = proposalData.evmClosePositionAction || {};
+          proposalPayload.marketplaceActions = [
+            {
+              exec: 'CLOSE_POSITION',
+              assetId: a.positionAsset || '',
+              positionId: a.positionId,
+              positionAsset: a.positionAsset,
+              underlyingAsset: a.underlyingAsset,
+              positionAmount: a.positionAmount,
+              market: 'Uniswap',
+            },
+          ];
+        } else if (marketActionType === 'swap') {
           proposalPayload.marketplaceActions = (proposalData.swapActions || []).map(action => ({
             assetId: action.assetId,
             exec: 'SELL',
@@ -477,6 +512,7 @@ export const CreateProposalModal = ({ onClose, isOpen, vault }) => {
                 assetsWhitelist={vault?.assetsWhitelist || []}
                 onDataChange={handleDataChange}
                 error={error}
+                isEvmVault={isEvmVault}
               />
             )}
             {selectedOption === 'expansion' && (

--- a/src/components/modals/CreateProposalModal/Expansion.jsx
+++ b/src/components/modals/CreateProposalModal/Expansion.jsx
@@ -6,9 +6,12 @@ import { LavaSteelInput } from '@/components/shared/LavaInput';
 import { LavaCheckbox } from '@/components/shared/LavaCheckbox';
 import { formatPolicyId } from '@/utils/core.utils';
 import { MIN_EXPANSION_DURATION_MS } from '@/components/vaults/constants/vaults.constants';
+import { ChainType } from '@/utils/types';
 
 export default function Expansion({ onDataChange, error, vault }) {
+  const isEvmVault = vault?.chainType === ChainType.ROBINHOOD;
   const [selectedPolicies, setSelectedPolicies] = useState([]);
+  const [evmAssets, setEvmAssets] = useState([]);
   const [duration, setDuration] = useState(null);
   const [noLimit, setNoLimit] = useState(false);
   const [assetMax, setAssetMax] = useState('');
@@ -16,7 +19,7 @@ export default function Expansion({ onDataChange, error, vault }) {
   const [priceType, setPriceType] = useState('market');
   const [limitPrice, setLimitPrice] = useState('');
 
-  // Get whitelisted policies from vault
+  // Get whitelisted policies/contracts from vault
   const whitelistedPolicies =
     vault?.assetsWhitelist?.map(w => ({
       value: w.policyId,
@@ -25,23 +28,33 @@ export default function Expansion({ onDataChange, error, vault }) {
     })) || [];
 
   const selectedPolicyValues = selectedPolicies.map(p => p.policyId || p);
+  // EVM selected values mirror the same shape; contractAddress === policyId on EVM
+  const selectedEvmValues = evmAssets.map(a => a.contractAddress);
 
   const priceTypeOptions = [
     { value: 'market', label: 'Market Price' },
     { value: 'limit', label: 'Limit Price' },
   ];
 
-  useEffect(() => {
-    // Cannot have both noLimit and noMax true - at least one limit must be set
-    const hasAtLeastOneLimit = !(noLimit && noMax);
+  const handleEvmAssetChange = values => {
+    const assetObjects = values.map(value => {
+      const option = whitelistedPolicies.find(opt => opt.value === value);
+      return { contractAddress: value, label: option?.label || value };
+    });
+    setEvmAssets(assetObjects);
+  };
 
+  useEffect(() => {
+    const hasAtLeastOneLimit = !(noLimit && noMax);
     const assetMaxNum = parseInt(assetMax) || 0;
     const limitPriceNum = parseFloat(limitPrice) || 0;
-    const MAX_ASSET_LIMIT = 1000000000000; // 1 trillion
-    const MAX_LIMIT_PRICE = 1000000; // 1 million VT
+    const MAX_ASSET_LIMIT = 1000000000000;
+    const MAX_LIMIT_PRICE = 1000000;
+
+    const assetsSelected = isEvmVault ? evmAssets.length > 0 : selectedPolicies.length > 0;
 
     const isValid =
-      selectedPolicies.length > 0 &&
+      assetsSelected &&
       (noLimit || duration > 0) &&
       (noMax || (assetMax && assetMaxNum > 0 && assetMaxNum <= MAX_ASSET_LIMIT)) &&
       hasAtLeastOneLimit &&
@@ -49,7 +62,8 @@ export default function Expansion({ onDataChange, error, vault }) {
       (priceType === 'market' || (limitPrice && limitPriceNum > 0 && limitPriceNum <= MAX_LIMIT_PRICE));
 
     onDataChange?.({
-      expansionPolicyIds: selectedPolicies,
+      expansionPolicyIds: isEvmVault ? [] : selectedPolicies,
+      expansionEvmAssets: isEvmVault ? evmAssets : [],
       expansionDuration: noLimit ? null : duration,
       expansionNoLimit: noLimit,
       expansionAssetMax: noMax ? null : Math.min(assetMaxNum, MAX_ASSET_LIMIT) || null,
@@ -58,15 +72,23 @@ export default function Expansion({ onDataChange, error, vault }) {
       expansionLimitPrice: priceType === 'limit' ? Math.min(limitPriceNum, MAX_LIMIT_PRICE) : null,
       isValid,
     });
-  }, [selectedPolicies, duration, noLimit, assetMax, noMax, priceType, limitPrice, onDataChange]);
+  }, [
+    selectedPolicies,
+    evmAssets,
+    duration,
+    noLimit,
+    assetMax,
+    noMax,
+    priceType,
+    limitPrice,
+    onDataChange,
+    isEvmVault,
+  ]);
 
   const handlePolicyChange = values => {
     const policyObjects = values.map(value => {
       const option = whitelistedPolicies.find(opt => opt.value === value);
-      return {
-        policyId: value,
-        label: option?.label || value,
-      };
+      return { policyId: value, label: option?.label || value };
     });
     setSelectedPolicies(policyObjects);
   };
@@ -83,23 +105,42 @@ export default function Expansion({ onDataChange, error, vault }) {
           </p>
         </div>
 
-        {/* Policy Selection */}
-        <div>
-          <label className="block text-sm font-medium text-gray-300 mb-2">Select Asset Collections*</label>
-          <LavaMultiSelect
-            options={whitelistedPolicies}
-            placeholder="Select Asset Collections"
-            value={selectedPolicyValues}
-            onChange={handlePolicyChange}
-            className="min-w-full"
-          />
-          <p className="text-xs text-gray-400 mt-1">
-            Select which whitelisted asset collections will be accepted during expansion
-          </p>
-          {error && selectedPolicies.length === 0 && (
-            <p className="text-red-500 text-sm mt-1">Select at least one policy</p>
-          )}
-        </div>
+        {/* Asset selection — Cardano: policy multiselect; EVM: contract address input */}
+        {isEvmVault ? (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Select Asset Contracts*</label>
+            <LavaMultiSelect
+              options={whitelistedPolicies}
+              placeholder="Select Asset Contracts"
+              value={selectedEvmValues}
+              onChange={handleEvmAssetChange}
+              className="min-w-full"
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Select which whitelisted contracts will be accepted during expansion
+            </p>
+            {error && evmAssets.length === 0 && (
+              <p className="text-red-500 text-sm mt-1">Select at least one contract</p>
+            )}
+          </div>
+        ) : (
+          <div>
+            <label className="block text-sm font-medium text-gray-300 mb-2">Select Asset Collections*</label>
+            <LavaMultiSelect
+              options={whitelistedPolicies}
+              placeholder="Select Asset Collections"
+              value={selectedPolicyValues}
+              onChange={handlePolicyChange}
+              className="min-w-full"
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Select which whitelisted asset collections will be accepted during expansion
+            </p>
+            {error && selectedPolicies.length === 0 && (
+              <p className="text-red-500 text-sm mt-1">Select at least one policy</p>
+            )}
+          </div>
+        )}
 
         {/* Duration */}
         <div>
@@ -224,20 +265,28 @@ export default function Expansion({ onDataChange, error, vault }) {
                   <strong>Market Price Calculation:</strong>
                 </p>
                 <p className="text-sm text-gray-300">Contributors will receive VT based on fair market value:</p>
-                <div className="p-3 bg-steel-800 rounded font-mono text-sm text-primary">
-                  VT Amount = (Asset Floor Price ₳) ÷ (VT Price ₳)
-                </div>
+                {isEvmVault ? (
+                  <div className="p-3 bg-steel-800 rounded font-mono text-sm text-primary">
+                    VT Amount = (Asset Floor Price) ÷ (VT Price from Uniswap)
+                  </div>
+                ) : (
+                  <div className="p-3 bg-steel-800 rounded font-mono text-sm text-primary">
+                    VT Amount = (Asset Floor Price ₳) ÷ (VT Price ₳)
+                  </div>
+                )}
                 <p className="text-xs text-gray-400">
-                  This ensures contributors receive a fair value equivalent in vault tokens based on current market
-                  prices
+                  {isEvmVault
+                    ? 'VT price is fetched from the Uniswap pool on Robinhood Chain at contribution close time'
+                    : 'This ensures contributors receive a fair value equivalent in vault tokens based on current market prices'}
                 </p>
               </div>
               {!vault?.hasActiveLp && (
                 <div className="p-3 bg-yellow-900/20 border border-yellow-600/50 rounded-lg">
                   <p className="text-yellow-400 text-sm font-medium">Market Pricing Requirements:</p>
                   <p className="text-yellow-300/90 text-xs mt-1">
-                    This vault does not have an active Liquidity Pool on DEXes. Market pricing requires an active LP
-                    with liquidity. Please use <strong>Limit Price</strong> instead.
+                    {isEvmVault
+                      ? 'This vault does not have an active Uniswap pool. Market pricing requires an active pool with liquidity. Please use Limit Price instead.'
+                      : 'This vault does not have an active Liquidity Pool on DEXes. Market pricing requires an active LP with liquidity. Please use Limit Price instead.'}
                   </p>
                 </div>
               )}
@@ -251,7 +300,13 @@ export default function Expansion({ onDataChange, error, vault }) {
           <div className="space-y-1 text-sm text-gray-300">
             <p>
               <span className="text-gray-400">Collections:</span>{' '}
-              {selectedPolicies.length > 0 ? `${selectedPolicies.length} selected` : 'None selected'}
+              {isEvmVault
+                ? evmAssets.length > 0
+                  ? `${evmAssets.length} contract(s)`
+                  : 'None added'
+                : selectedPolicies.length > 0
+                  ? `${selectedPolicies.length} selected`
+                  : 'None selected'}
             </p>
             <p>
               <span className="text-gray-400">Duration:</span>{' '}

--- a/src/components/modals/CreateProposalModal/MarketActions/EvmClosePositionAction.jsx
+++ b/src/components/modals/CreateProposalModal/MarketActions/EvmClosePositionAction.jsx
@@ -7,6 +7,8 @@ const ERC20_DECIMALS_ABI = [
   { type: 'function', stateMutability: 'view', name: 'decimals', inputs: [], outputs: [{ type: 'uint8' }] },
 ];
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 const isValidAddress = addr => /^0x[0-9a-fA-F]{40}$/.test(addr);
 
 const toRaw = (human, decimals) => {
@@ -31,13 +33,14 @@ const EvmClosePositionAction = ({ onDataChange, error }) => {
   const [decimals, setDecimals] = useState(18);
 
   const update = (field, value) => setAction(prev => ({ ...prev, [field]: value }));
+  const validPositionAsset = isValidAddress(action.positionAsset);
 
   // Fetch decimals from the position asset contract.
   const { data: resolvedDecimals } = useReadContract({
-    address: action.positionAsset,
+    address: validPositionAsset ? action.positionAsset : ZERO_ADDRESS,
     abi: ERC20_DECIMALS_ABI,
     functionName: 'decimals',
-    query: { enabled: isValidAddress(action.positionAsset) },
+    query: { enabled: validPositionAsset },
   });
 
   useEffect(() => {

--- a/src/components/modals/CreateProposalModal/MarketActions/EvmClosePositionAction.jsx
+++ b/src/components/modals/CreateProposalModal/MarketActions/EvmClosePositionAction.jsx
@@ -1,0 +1,105 @@
+import { useEffect, useState } from 'react';
+import { useReadContract } from 'wagmi';
+
+import { LavaSteelInput } from '@/components/shared/LavaInput';
+
+const ERC20_DECIMALS_ABI = [
+  { type: 'function', stateMutability: 'view', name: 'decimals', inputs: [], outputs: [{ type: 'uint8' }] },
+];
+
+const isValidAddress = addr => /^0x[0-9a-fA-F]{40}$/.test(addr);
+
+const toRaw = (human, decimals) => {
+  const n = parseFloat(human);
+  if (!human || isNaN(n) || n <= 0) return '0';
+  return String(BigInt(Math.round(n * 10 ** decimals)));
+};
+
+const isValid = action =>
+  Number(action.positionId) > 0 &&
+  isValidAddress(action.positionAsset) &&
+  isValidAddress(action.underlyingAsset) &&
+  parseFloat(action.humanAmount) > 0;
+
+const EvmClosePositionAction = ({ onDataChange, error }) => {
+  const [action, setAction] = useState({
+    positionId: '',
+    positionAsset: '',
+    underlyingAsset: '',
+    humanAmount: '',
+  });
+  const [decimals, setDecimals] = useState(18);
+
+  const update = (field, value) => setAction(prev => ({ ...prev, [field]: value }));
+
+  // Fetch decimals from the position asset contract.
+  const { data: resolvedDecimals } = useReadContract({
+    address: action.positionAsset,
+    abi: ERC20_DECIMALS_ABI,
+    functionName: 'decimals',
+    query: { enabled: isValidAddress(action.positionAsset) },
+  });
+
+  useEffect(() => {
+    if (resolvedDecimals != null) setDecimals(Number(resolvedDecimals));
+  }, [resolvedDecimals]);
+
+  useEffect(() => {
+    onDataChange({
+      marketActionType: 'evm_close_position',
+      evmClosePositionAction: { ...action, positionAmount: toRaw(action.humanAmount, decimals) },
+      isValid: isValid(action, decimals),
+    });
+  }, [action, decimals, onDataChange]);
+
+  const invalid = error && !isValid(action, decimals);
+  const rawPreview = isValid(action, decimals) ? toRaw(action.humanAmount, decimals) : null;
+
+  return (
+    <div className="space-y-5">
+      <h3 className="text-lg font-medium">Close Position</h3>
+      <p className="text-sm text-white/40">
+        Unwinds an open Uniswap adapter position by swapping the held token back to the underlying asset. The backend
+        computes the minimum return automatically.
+      </p>
+
+      <div className="bg-steel-800 rounded-lg p-4 space-y-4">
+        <LavaSteelInput
+          label="Position ID (on-chain)"
+          placeholder="e.g. 3"
+          value={action.positionId}
+          onChange={v => update('positionId', v)}
+          error={invalid && !(Number(action.positionId) > 0)}
+          helperText="The numeric position ID emitted by the PositionOpened event"
+        />
+        <LavaSteelInput
+          label="Position asset (token currently held)"
+          placeholder="0x..."
+          value={action.positionAsset}
+          onChange={v => update('positionAsset', v)}
+          error={invalid && !isValidAddress(action.positionAsset)}
+          helperText={isValidAddress(action.positionAsset) ? `Decimals: ${decimals}` : undefined}
+        />
+        <LavaSteelInput
+          label="Underlying asset (swap back to)"
+          placeholder="0x..."
+          value={action.underlyingAsset}
+          onChange={v => update('underlyingAsset', v)}
+          error={invalid && !isValidAddress(action.underlyingAsset)}
+        />
+        <LavaSteelInput
+          label={`Amount${decimals !== 18 ? ` (token has ${decimals} decimals)` : ''}`}
+          placeholder="e.g. 1.5"
+          value={action.humanAmount}
+          onChange={v => update('humanAmount', v)}
+          error={invalid && !(parseFloat(action.humanAmount) > 0)}
+          helperText={rawPreview && `Raw on-chain: ${rawPreview}`}
+        />
+      </div>
+
+      {invalid && <p className="text-red-500 text-sm">Please fill in all fields with valid values.</p>}
+    </div>
+  );
+};
+
+export default EvmClosePositionAction;

--- a/src/components/modals/CreateProposalModal/MarketActions/EvmSwapAction.jsx
+++ b/src/components/modals/CreateProposalModal/MarketActions/EvmSwapAction.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Plus, X, ArrowRight } from 'lucide-react';
 import { useReadContract } from 'wagmi';
 
@@ -8,20 +8,23 @@ const ERC20_DECIMALS_ABI = [
   { type: 'function', stateMutability: 'view', name: 'decimals', inputs: [], outputs: [{ type: 'uint8' }] },
 ];
 
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+
 const isValidAddress = addr => /^0x[0-9a-fA-F]{40}$/.test(addr);
 
 /** Fetches ERC-20 decimals for a given address and notifies the parent. */
-const DecimalsResolver = ({ address, onResolved }) => {
+const DecimalsResolver = ({ address, actionId, onResolved }) => {
+  const validAddress = isValidAddress(address);
   const { data } = useReadContract({
-    address,
+    address: validAddress ? address : ZERO_ADDRESS,
     abi: ERC20_DECIMALS_ABI,
     functionName: 'decimals',
-    query: { enabled: isValidAddress(address) },
+    query: { enabled: validAddress },
   });
 
   useEffect(() => {
-    if (data != null) onResolved(Number(data));
-  }, [data, onResolved]);
+    if (data != null) onResolved(actionId, Number(data));
+  }, [actionId, data, onResolved]);
 
   return null;
 };
@@ -50,6 +53,18 @@ const isValidAction = action =>
 
 const EvmSwapAction = ({ onDataChange, error }) => {
   const [actions, setActions] = useState([emptyAction()]);
+
+  const updateDecimals = useCallback((id, decimals) => {
+    setActions(prev => {
+      let changed = false;
+      const next = prev.map(action => {
+        if (action.id !== id || action.decimals === decimals) return action;
+        changed = true;
+        return { ...action, decimals };
+      });
+      return changed ? next : prev;
+    });
+  }, []);
 
   useEffect(() => {
     onDataChange({
@@ -89,7 +104,7 @@ const EvmSwapAction = ({ onDataChange, error }) => {
         return (
           <div key={action.id} className="bg-steel-800 rounded-lg p-4 space-y-4">
             {/* resolve decimals silently when the input address is valid */}
-            <DecimalsResolver address={action.inputAsset} onResolved={d => update(action.id, 'decimals', d)} />
+            <DecimalsResolver address={action.inputAsset} actionId={action.id} onResolved={updateDecimals} />
 
             <div className="flex justify-between items-center">
               <span className="font-medium text-sm">

--- a/src/components/modals/CreateProposalModal/MarketActions/EvmSwapAction.jsx
+++ b/src/components/modals/CreateProposalModal/MarketActions/EvmSwapAction.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useState } from 'react';
+import { Plus, X, ArrowRight } from 'lucide-react';
+import { useReadContract } from 'wagmi';
+
+import { LavaSteelInput } from '@/components/shared/LavaInput';
+
+const ERC20_DECIMALS_ABI = [
+  { type: 'function', stateMutability: 'view', name: 'decimals', inputs: [], outputs: [{ type: 'uint8' }] },
+];
+
+const isValidAddress = addr => /^0x[0-9a-fA-F]{40}$/.test(addr);
+
+/** Fetches ERC-20 decimals for a given address and notifies the parent. */
+const DecimalsResolver = ({ address, onResolved }) => {
+  const { data } = useReadContract({
+    address,
+    abi: ERC20_DECIMALS_ABI,
+    functionName: 'decimals',
+    query: { enabled: isValidAddress(address) },
+  });
+
+  useEffect(() => {
+    if (data != null) onResolved(Number(data));
+  }, [data, onResolved]);
+
+  return null;
+};
+
+/** Convert human-readable amount to raw bigint string using token decimals. */
+const toRaw = (human, decimals) => {
+  const n = parseFloat(human);
+  if (!human || isNaN(n) || n <= 0) return '0';
+  const factor = 10 ** decimals;
+  return String(BigInt(Math.round(n * factor)));
+};
+
+const emptyAction = () => ({
+  id: Date.now() + Math.random(),
+  inputAsset: '',
+  outputAsset: '',
+  humanAmount: '',
+  decimals: 18, // default; updated by DecimalsResolver when address resolves
+});
+
+const isValidAction = action =>
+  isValidAddress(action.inputAsset) &&
+  isValidAddress(action.outputAsset) &&
+  action.inputAsset.toLowerCase() !== action.outputAsset.toLowerCase() &&
+  parseFloat(action.humanAmount) > 0;
+
+const EvmSwapAction = ({ onDataChange, error }) => {
+  const [actions, setActions] = useState([emptyAction()]);
+
+  useEffect(() => {
+    onDataChange({
+      marketActionType: 'evm_swap',
+      evmSwapActions: actions.map(a => ({ ...a, amount: toRaw(a.humanAmount, a.decimals) })),
+      isValid: actions.length > 0 && actions.every(isValidAction),
+    });
+  }, [actions, onDataChange]);
+
+  const update = (id, field, value) => setActions(prev => prev.map(a => (a.id === id ? { ...a, [field]: value } : a)));
+
+  const add = () => setActions(prev => [...prev, emptyAction()]);
+  const remove = id => setActions(prev => prev.filter(a => a.id !== id));
+
+  return (
+    <div className="space-y-5">
+      <div className="flex justify-between items-center">
+        <h3 className="text-lg font-medium">EVM Swap Actions</h3>
+        <button
+          type="button"
+          onClick={add}
+          className="flex items-center gap-2 bg-steel-850 hover:bg-steel-850/70 text-white/60 px-4 py-2 rounded-lg transition-colors border border-steel-750"
+        >
+          Add Swap <Plus className="h-4 w-4" />
+        </button>
+      </div>
+
+      <p className="text-sm text-white/40">
+        Each swap calls UniswapV3 on Robinhood Chain via the vault adapter. Token decimals are fetched automatically
+        once you enter a valid ERC-20 address.
+      </p>
+
+      {actions.map((action, index) => {
+        const invalid = error && !isValidAction(action);
+        const rawPreview = isValidAction(action) ? toRaw(action.humanAmount, action.decimals) : null;
+
+        return (
+          <div key={action.id} className="bg-steel-800 rounded-lg p-4 space-y-4">
+            {/* resolve decimals silently when the input address is valid */}
+            <DecimalsResolver address={action.inputAsset} onResolved={d => update(action.id, 'decimals', d)} />
+
+            <div className="flex justify-between items-center">
+              <span className="font-medium text-sm">
+                Swap {index + 1}
+                {invalid && <span className="text-red-500 ml-2">Fill in valid addresses and amount</span>}
+              </span>
+              {actions.length > 1 && (
+                <button type="button" onClick={() => remove(action.id)} className="text-red-400 hover:text-red-500 p-1">
+                  <X className="h-4 w-4" />
+                </button>
+              )}
+            </div>
+
+            <div className="grid grid-cols-1 md:grid-cols-[1fr_auto_1fr] gap-3 items-end">
+              <LavaSteelInput
+                label="Input token (ERC-20 address)"
+                placeholder="0x..."
+                value={action.inputAsset}
+                onChange={v => update(action.id, 'inputAsset', v)}
+                error={invalid && !isValidAddress(action.inputAsset)}
+              />
+              <div className="flex items-center justify-center pb-2">
+                <ArrowRight className="h-5 w-5 text-white/40" />
+              </div>
+              <LavaSteelInput
+                label="Output token (ERC-20 address)"
+                placeholder="0x..."
+                value={action.outputAsset}
+                onChange={v => update(action.id, 'outputAsset', v)}
+                error={invalid && !isValidAddress(action.outputAsset)}
+              />
+            </div>
+
+            <LavaSteelInput
+              label={`Amount${action.decimals !== 18 ? ` (token has ${action.decimals} decimals)` : ''}`}
+              placeholder="e.g. 1.5"
+              value={action.humanAmount}
+              onChange={v => update(action.id, 'humanAmount', v)}
+              error={invalid && !(parseFloat(action.humanAmount) > 0)}
+              helperText={rawPreview && `Raw on-chain: ${rawPreview}`}
+            />
+          </div>
+        );
+      })}
+    </div>
+  );
+};
+
+export default EvmSwapAction;

--- a/src/components/modals/CreateProposalModal/MarketActions/MarketActions.jsx
+++ b/src/components/modals/CreateProposalModal/MarketActions/MarketActions.jsx
@@ -1,6 +1,8 @@
 import { useCallback, useState } from 'react';
 
 import SwapAction from './SwapAction';
+import EvmSwapAction from './EvmSwapAction';
+import EvmClosePositionAction from './EvmClosePositionAction';
 
 import { LavaSteelSelect } from '@/components/shared/LavaSelect.jsx';
 import { UnlistAction } from '@/components/modals/CreateProposalModal/MarketActions/UnlistAction.jsx';
@@ -9,16 +11,22 @@ import { BuyAction } from '@/components/modals/CreateProposalModal/MarketActions
 import { SellAction } from '@/components/modals/CreateProposalModal/MarketActions/SellAction.jsx';
 import { CancelOfferAction } from '@/components/modals/CreateProposalModal/MarketActions/CancelOfferAction.jsx';
 
-const marketOptions = [
+const cardanoMarketOptions = [
   { value: 'sell', label: 'Sell' },
   { value: 'unlist', label: 'Unlist' },
   { value: 'update_list', label: 'Update List' },
   { value: 'buy', label: 'Buy/Offer' },
   { value: 'cancel_offer', label: 'Cancel Offer' },
-  { value: 'swap', label: 'Swap - Coming Soon', disabled: true },
+  { value: 'swap', label: 'Swap (DexHunter)' },
 ];
 
-export const MarketActions = ({ vaultId, assetsWhitelist, onDataChange, error }) => {
+const evmMarketOptions = [
+  { value: 'evm_swap', label: 'Swap (Uniswap V3)' },
+  { value: 'evm_close_position', label: 'Close Position' },
+];
+
+export const MarketActions = ({ vaultId, assetsWhitelist, onDataChange, error, isEvmVault }) => {
+  const marketOptions = isEvmVault ? evmMarketOptions : cardanoMarketOptions;
   const [selectedOption, setSelectedOption] = useState(marketOptions[0].value);
 
   const handleOptionChange = value => {
@@ -51,7 +59,8 @@ export const MarketActions = ({ vaultId, assetsWhitelist, onDataChange, error })
         value={selectedOption}
         onChange={handleOptionChange}
       />
-      {selectedOption === 'buy' && (
+      {/* Cardano actions */}
+      {!isEvmVault && selectedOption === 'buy' && (
         <BuyAction
           error={error}
           vaultId={vaultId}
@@ -59,16 +68,27 @@ export const MarketActions = ({ vaultId, assetsWhitelist, onDataChange, error })
           onDataChange={handleActionDataChange}
         />
       )}
-      {selectedOption === 'sell' && (
+      {!isEvmVault && selectedOption === 'sell' && (
         <SellAction error={error} vaultId={vaultId} onDataChange={handleActionDataChange} />
       )}
-      {selectedOption === 'swap' && <SwapAction vaultId={vaultId} onDataChange={handleActionDataChange} />}
-      {selectedOption === 'unlist' && <UnlistAction vaultId={vaultId} onDataChange={handleActionDataChange} />}
-      {selectedOption === 'update_list' && (
+      {!isEvmVault && selectedOption === 'swap' && (
+        <SwapAction vaultId={vaultId} onDataChange={handleActionDataChange} />
+      )}
+      {!isEvmVault && selectedOption === 'unlist' && (
+        <UnlistAction vaultId={vaultId} onDataChange={handleActionDataChange} />
+      )}
+      {!isEvmVault && selectedOption === 'update_list' && (
         <UpdateListingAction vaultId={vaultId} onDataChange={handleActionDataChange} />
       )}
-      {selectedOption === 'cancel_offer' && (
+      {!isEvmVault && selectedOption === 'cancel_offer' && (
         <CancelOfferAction vaultId={vaultId} onDataChange={handleActionDataChange} />
+      )}
+      {/* EVM actions */}
+      {isEvmVault && selectedOption === 'evm_swap' && (
+        <EvmSwapAction onDataChange={handleActionDataChange} error={error} />
+      )}
+      {isEvmVault && selectedOption === 'evm_close_position' && (
+        <EvmClosePositionAction onDataChange={handleActionDataChange} error={error} />
       )}
     </div>
   );

--- a/src/components/shared/LavaDatePicker.jsx
+++ b/src/components/shared/LavaDatePicker.jsx
@@ -113,6 +113,11 @@ export const LavaDatePicker = ({
 
   const hours = Array.from({ length: 12 }, (_, i) => i + 1);
   const styles = variants[variant];
+  const optionBaseClasses =
+    'sm:w-full shrink-0 aspect-square transition-all duration-200 bg-steel-850 text-steel-300 hover:bg-steel-800 hover:text-white';
+  const optionActiveClasses = 'bg-orange-500 text-steel-950 hover:bg-orange-500 hover:text-steel-950';
+  const optionDisabledClasses =
+    'bg-steel-900 text-steel-600 cursor-not-allowed hover:bg-steel-900 hover:text-steel-600';
 
   return (
     <>
@@ -183,7 +188,7 @@ export const LavaDatePicker = ({
                     outside: 'text-muted-foreground aria-selected:text-muted-foreground',
                     disabled: 'text-muted-foreground opacity-50',
                     selected:
-                      'bg-primary text-primary-foreground hover:bg-primary hover:text-primary-foreground focus:bg-primary focus:text-primary-foreground',
+                      'bg-orange-500 text-steel-950 hover:bg-orange-500 hover:text-steel-950 focus:bg-orange-500 focus:text-steel-950',
                   }}
                   disabled={date => {
                     const minimumDate = minDate || startOfToday();
@@ -203,10 +208,16 @@ export const LavaDatePicker = ({
                         return (
                           <Button
                             key={hour}
-                            className="sm:w-full shrink-0 aspect-square"
+                            className={cn(
+                              optionBaseClasses,
+                              dateValue && getHours(dateValue) % 12 === hour % 12
+                                ? optionActiveClasses
+                                : 'text-steel-400',
+                              (!dateValue || isHourDisabled) && optionDisabledClasses
+                            )}
                             size="icon"
                             disabled={!dateValue || isHourDisabled}
-                            variant={dateValue && getHours(dateValue) % 12 === hour % 12 ? 'default' : 'ghost'}
+                            variant="ghost"
                             onClick={() => handleTimeChange('hour', hour.toString())}
                           >
                             {hour}
@@ -218,43 +229,56 @@ export const LavaDatePicker = ({
                   </ScrollArea>
                   <ScrollArea className={cn('w-64 sm:w-auto', styles.scrollArea)}>
                     <div className="flex sm:flex-col p-2">
-                      {Array.from({ length: 12 }, (_, i) => i * 5).map(minute => (
-                        <Button
-                          key={minute}
-                          className="sm:w-full shrink-0 aspect-square"
-                          size="icon"
-                          disabled={
-                            !dateValue || (isToday && getHours(dateValue) === currentHour && minute < currentMinute)
-                          }
-                          variant={dateValue && getMinutes(dateValue) === minute ? 'default' : 'ghost'}
-                          onClick={() => handleTimeChange('minute', minute.toString())}
-                        >
-                          {minute}
-                        </Button>
-                      ))}
+                      {Array.from({ length: 12 }, (_, i) => i * 5).map(minute => {
+                        const isMinuteSelected = dateValue && getMinutes(dateValue) === minute;
+                        const isMinuteDisabled =
+                          !dateValue || (isToday && getHours(dateValue) === currentHour && minute < currentMinute);
+                        return (
+                          <Button
+                            key={minute}
+                            className={cn(
+                              optionBaseClasses,
+                              isMinuteSelected ? optionActiveClasses : 'text-steel-400',
+                              isMinuteDisabled && optionDisabledClasses
+                            )}
+                            size="icon"
+                            disabled={isMinuteDisabled}
+                            variant="ghost"
+                            onClick={() => handleTimeChange('minute', minute.toString())}
+                          >
+                            {minute}
+                          </Button>
+                        );
+                      })}
                     </div>
                     <ScrollBar className="sm:hidden" orientation="horizontal" />
                   </ScrollArea>
                   <ScrollArea className={cn(styles.scrollArea, 'rounded-[10px]')}>
                     <div className="flex sm:flex-col p-2">
-                      {['AM', 'PM'].map(ampm => (
-                        <Button
-                          key={ampm}
-                          className="sm:w-full shrink-0 aspect-square"
-                          size="icon"
-                          disabled={!dateValue || (isToday && ampm === 'AM' && currentHour >= 12)}
-                          variant={
-                            dateValue &&
-                            ((ampm === 'AM' && getHours(dateValue) < 12) ||
-                              (ampm === 'PM' && getHours(dateValue) >= 12))
-                              ? 'default'
-                              : 'ghost'
-                          }
-                          onClick={() => handleTimeChange('ampm', ampm)}
-                        >
-                          {ampm}
-                        </Button>
-                      ))}
+                      {['AM', 'PM'].map(ampm => {
+                        let isAmPmSelected = false;
+                        if (dateValue) {
+                          const selectedHour = getHours(dateValue);
+                          isAmPmSelected = ampm === 'AM' ? selectedHour < 12 : selectedHour >= 12;
+                        }
+                        const isAmPmDisabled = !dateValue || (isToday && ampm === 'AM' && currentHour >= 12);
+                        return (
+                          <Button
+                            key={ampm}
+                            className={cn(
+                              optionBaseClasses,
+                              isAmPmSelected ? optionActiveClasses : 'text-steel-400',
+                              isAmPmDisabled && optionDisabledClasses
+                            )}
+                            size="icon"
+                            disabled={isAmPmDisabled}
+                            variant="ghost"
+                            onClick={() => handleTimeChange('ampm', ampm)}
+                          >
+                            {ampm}
+                          </Button>
+                        );
+                      })}
                     </div>
                   </ScrollArea>
                 </div>

--- a/src/components/shared/LavaIntervalPicker.tsx
+++ b/src/components/shared/LavaIntervalPicker.tsx
@@ -73,6 +73,11 @@ export const LavaIntervalPicker = ({
   const days = Array.from({ length: dayCount }, (_, i) => i + minInterval.days);
   const hours = Array.from({ length: 24 }, (_, i) => i);
   const minutes = Array.from({ length: 12 }, (_, i) => i * 5);
+  const optionBaseClasses =
+    'w-12 h-12 transition-all duration-200 bg-steel-850 text-steel-300 hover:bg-steel-800 hover:text-white';
+  const optionActiveClasses = 'bg-orange-500 text-steel-950 hover:bg-orange-500 hover:text-steel-950';
+  const optionDisabledClasses =
+    'bg-steel-900 text-steel-600 cursor-not-allowed hover:bg-steel-900 hover:text-steel-600';
   const isValidSelection = (newInterval: { days: number; hours: number; minutes: number }) => {
     const totalMs = intervalToMs(newInterval);
     const minTotalMs = minMs > 0 ? minMs : intervalToMs(minInterval);
@@ -138,9 +143,12 @@ export const LavaIntervalPicker = ({
                       {days.map(day => (
                         <Button
                           key={day}
-                          className="w-12 h-12"
+                          className={cn(
+                            optionBaseClasses,
+                            interval.days === day ? optionActiveClasses : 'text-steel-400'
+                          )}
                           size="icon"
-                          variant={interval.days === day ? 'default' : 'ghost'}
+                          variant="ghost"
                           onClick={() => handleIntervalChange('days', day.toString())}
                         >
                           {day}
@@ -160,9 +168,13 @@ export const LavaIntervalPicker = ({
                         return (
                           <Button
                             key={hour}
-                            className="w-12 h-12"
+                            className={cn(
+                              optionBaseClasses,
+                              interval.hours === hour ? optionActiveClasses : 'text-steel-400',
+                              isDisabled && optionDisabledClasses
+                            )}
                             size="icon"
-                            variant={interval.hours === hour ? 'default' : 'ghost'}
+                            variant="ghost"
                             disabled={isDisabled}
                             onClick={() => handleIntervalChange('hours', hour.toString())}
                           >
@@ -184,9 +196,13 @@ export const LavaIntervalPicker = ({
                         return (
                           <Button
                             key={minute}
-                            className="w-12 h-12"
+                            className={cn(
+                              optionBaseClasses,
+                              interval.minutes === minute ? optionActiveClasses : 'text-steel-400',
+                              isDisabled && optionDisabledClasses
+                            )}
                             size="icon"
-                            variant={interval.minutes === minute ? 'default' : 'ghost'}
+                            variant="ghost"
                             disabled={isDisabled}
                             onClick={() => handleIntervalChange('minutes', minute.toString())}
                           >

--- a/src/components/shared/LavaWhitelistWithCaps.jsx
+++ b/src/components/shared/LavaWhitelistWithCaps.jsx
@@ -514,7 +514,6 @@ export const LavaWhitelistWithCaps = ({
 
     return (
       <button
-        key={`${policy.policyId}-${policy.name}`}
         type="button"
         disabled={!isVerified}
         className={`w-full px-4 py-2 text-left flex items-center gap-3 border-b border-steel-700 last:border-b-0 ${
@@ -587,7 +586,7 @@ export const LavaWhitelistWithCaps = ({
             <span className="uppercase font-bold text-sm text-dark-100">*Asset valuation method</span>
           </div>
         )}
-        {whitelist.map(asset => {
+        {whitelist.map((asset, index) => {
           const isSearchMode = !!asset.policyId;
           const policiesToShow = isSearchMode
             ? getFilteredSearchResults(asset.uniqueId)
@@ -600,7 +599,7 @@ export const LavaWhitelistWithCaps = ({
 
           return (
             <div
-              key={asset.id || asset.uniqueId}
+              key={asset.id || asset.uniqueId || `asset-${index}`}
               className={cn('p-4 grid gap-4 items-start', showCountCaps ? tableGridCols : 'grid-cols-1')}
             >
               <div className={styles.itemSpacing}>
@@ -654,8 +653,10 @@ export const LavaWhitelistWithCaps = ({
                       ) : policiesToShow.length > 0 ? (
                         <>
                           <div className="space-y-0">
-                            {policiesToShow.map(policy => (
-                              <div key={policy.policyId}>{renderAssetItem(asset, policy)}</div>
+                            {policiesToShow.map((policy, policyIndex) => (
+                              <div key={`${policy.policyId}-${policy.name || 'asset'}-${policyIndex}`}>
+                                {renderAssetItem(asset, policy)}
+                              </div>
                             ))}
                           </div>
                           {!isSearchMode && isLoadingMore && (

--- a/src/components/vault-profile/ProposalInfo.jsx
+++ b/src/components/vault-profile/ProposalInfo.jsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/lib/auth/auth';
 import { useModalControls } from '@/lib/modals/modal.context';
 import { getInProgressMessage, getSuccessMessage, getTerminationStatusMessage } from '@/constants/proposalMessages';
 import { useCurrency } from '@/hooks/useCurrency';
+import { useRewardsWalletConnection } from '@/hooks/useRewardsWalletConnection';
 
 const ProposalInfoSkeleton = () => (
   <div>
@@ -107,6 +108,7 @@ const ProposalInfoSkeleton = () => (
 export const ProposalInfo = ({ proposalId }) => {
   const { currencyLabel } = useCurrency();
   const { user } = useAuth();
+  const { walletAddress, isWalletConnected } = useRewardsWalletConnection();
   const { openModal } = useModalControls();
   const router = useRouter();
 
@@ -456,7 +458,9 @@ export const ProposalInfo = ({ proposalId }) => {
   const voteOnProposal = useVoteOnProposal(proposalInfo?.vaultId);
 
   const handleVote = async (proposalId, voteType) => {
-    if (!user) {
+    const activeVoterAddress = walletAddress || user?.address;
+
+    if (!user || !isWalletConnected || !activeVoterAddress) {
       openModal('LoginModal');
       return;
     }
@@ -470,7 +474,7 @@ export const ProposalInfo = ({ proposalId }) => {
             proposalId,
             voteData: {
               vote: voteType.toLowerCase(),
-              voterAddress: user.address,
+              voterAddress: activeVoterAddress,
             },
           });
           setCanVote(false);

--- a/src/components/vault-profile/ProposalInfo/MarketplaceActionsList.jsx
+++ b/src/components/vault-profile/ProposalInfo/MarketplaceActionsList.jsx
@@ -12,14 +12,17 @@ const ActionField = ({ label, value, children, className }) => (
   </div>
 );
 
+/** Truncate a 0x address for display. */
+const shortAddr = addr => (addr ? `${addr.slice(0, 8)}\u2026${addr.slice(-6)}` : 'N/A');
+
 export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainType }) => {
   const { currencyLabel } = useCurrency();
 
   if (!Array.isArray(actions) || actions.length === 0) return null;
 
-  // Check if this is a DexHunter swap action
-  // DexHunter swaps have market='DexHunter' OR have slippage field (unique to swaps)
   const isDexHunterSwap = actions[0]?.market === 'DexHunter' || actions[0]?.slippage !== undefined;
+  const isEvmUniswapSwap = actions[0]?.market === 'Uniswap' && actions[0]?.inputAsset;
+  const isEvmClosePosition = actions[0]?.exec === 'CLOSE_POSITION';
 
   return (
     <div className="flex flex-col gap-4">
@@ -29,10 +32,39 @@ export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainTyp
       </div>
       <div className="space-y-4 pl-4 border-l border-steel-750">
         {actions.map((action, index) => (
-          <div key={action.assetId} className="space-y-2">
+          <div key={index} className="space-y-2">
             <div className="text-sm text-gray-500">Action {index + 1}</div>
             <div className="space-y-2">
-              {isDexHunterSwap ? (
+              {isEvmUniswapSwap ? (
+                <>
+                  <ActionField label="Market" value="Uniswap V3 (Robinhood Chain)" />
+                  <ActionField label="Type" value="Token Swap" />
+                  <ActionField label="Input Token" value={shortAddr(action.inputAsset)} />
+                  <ActionField label="Output Token" value={shortAddr(action.expectedOutputAsset)} />
+                  {(action.humanAmount || action.amount) && (
+                    <ActionField label="Amount" value={action.humanAmount || action.amount} />
+                  )}
+                  {action.assetStatus && (
+                    <ActionField label="Status" className="uppercase" value={action.assetStatus} />
+                  )}
+                </>
+              ) : isEvmClosePosition ? (
+                <>
+                  <ActionField label="Market" value="Uniswap V3 (Robinhood Chain)" />
+                  <ActionField label="Type" value="Close Position" />
+                  {action.positionId && <ActionField label="Position ID" value={action.positionId} />}
+                  {action.positionAsset && (
+                    <ActionField label="Position Asset" value={shortAddr(action.positionAsset)} />
+                  )}
+                  {action.underlyingAsset && (
+                    <ActionField label="Return To" value={shortAddr(action.underlyingAsset)} />
+                  )}
+                  {action.positionAmount && <ActionField label="Amount (raw)" value={action.positionAmount} />}
+                  {action.assetStatus && (
+                    <ActionField label="Status" className="uppercase" value={action.assetStatus} />
+                  )}
+                </>
+              ) : isDexHunterSwap ? (
                 <>
                   <ActionField label="Market" value={action.market || 'DexHunter'} />
                   <ActionField label="Type" value={`Swap to ${currencyLabel}`} />
@@ -60,13 +92,16 @@ export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainTyp
                     />
                   )}
                   {!action.useMarketPrice && action.customPriceAda && (
-                    <ActionField label="Custom Price" value={`₳${formatAdaPrice(action.customPriceAda)} per token`} />
+                    <ActionField
+                      label="Custom Price"
+                      value={`\u20B3${formatAdaPrice(action.customPriceAda)} per token`}
+                    />
                   )}
                   {action.estimatedOutput && (
-                    <ActionField label="Estimated Output" value={`₳${formatAdaPrice(action.estimatedOutput)}`} />
+                    <ActionField label="Estimated Output" value={`\u20B3${formatAdaPrice(action.estimatedOutput)}`} />
                   )}
                   {action.actualOutput && (
-                    <ActionField label="Actual Output" value={`₳${formatAdaPrice(action.actualOutput)}`} />
+                    <ActionField label="Actual Output" value={`\u20B3${formatAdaPrice(action.actualOutput)}`} />
                   )}
                   {action.txHash && (
                     <ActionField label="Transaction">
@@ -76,7 +111,7 @@ export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainTyp
                         rel="noopener noreferrer"
                         className="flex items-center gap-1 text-orange-500 hover:text-orange-400 transition-colors text-sm"
                       >
-                        <span>View on Cardanoscan</span>
+                        <span>View on Explorer</span>
                         <ExternalLink className="h-3 w-3" />
                       </a>
                     </ActionField>
@@ -90,18 +125,20 @@ export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainTyp
                   <ActionField label="Exec" value={action.exec} />
                   <ActionField label="Market" value={action.market || 'WayUp'} />
                   {action.assetPrice && String(action.exec || '').toLowerCase() !== 'offer' && (
-                    <ActionField label="Floor Price" value={`₳${formatAdaPrice(action.assetPrice)}`} />
+                    <ActionField label="Floor Price" value={`\u20B3${formatAdaPrice(action.assetPrice)}`} />
                   )}
                   {action.price && (
                     <ActionField
                       label={String(action.exec || '').toLowerCase() === 'offer' ? 'Offered Price' : 'Buying Max Price'}
-                      value={`₳${formatAdaPrice(action.price)}`}
+                      value={`\u20B3${formatAdaPrice(action.price)}`}
                     />
                   )}
                   {action.listingPrice && (
-                    <ActionField label="Listing Price" value={`₳${formatAdaPrice(action.listingPrice)}`} />
+                    <ActionField label="Listing Price" value={`\u20B3${formatAdaPrice(action.listingPrice)}`} />
                   )}
-                  {action.newPrice && <ActionField label="New Price" value={`₳${formatAdaPrice(action.newPrice)}`} />}
+                  {action.newPrice && (
+                    <ActionField label="New Price" value={`\u20B3${formatAdaPrice(action.newPrice)}`} />
+                  )}
                   {action.assetName && <ActionField label="Asset Name" value={action.assetName} />}
                   {action.assetImg && (
                     <ActionField label="Asset Image">
@@ -140,7 +177,9 @@ export const MarketplaceActionsList = ({ actions, type = 'marketplace', chainTyp
                   {action.sellType && <ActionField label="Sell Type" value={action.sellType} />}
                   {action.method && <ActionField label="Method" value={action.method} />}
                   {action.market && <ActionField label="Market" value={action.market} />}
-                  {action.assetPrice && <ActionField label="Price" value={`₳${formatAdaPrice(action.assetPrice)}`} />}
+                  {action.assetPrice && (
+                    <ActionField label="Price" value={`\u20B3${formatAdaPrice(action.assetPrice)}`} />
+                  )}
                   {action.assetStatus && (
                     <ActionField label="Status" className="uppercase" value={action.assetStatus} />
                   )}

--- a/src/components/vault-profile/ProposalInfo/VoteButton.jsx
+++ b/src/components/vault-profile/ProposalInfo/VoteButton.jsx
@@ -1,18 +1,20 @@
 export const VoteButton = ({ voteType, icon: Icon, label, canVote, isSelected, onClick }) => {
+  const baseBackground = 'var(--color-steel-850)';
+
   const getStyles = () => {
     const getBackground = () => {
-      if (!canVote) return '#2D3049';
+      if (!canVote) return baseBackground;
       if (voteType === 'yes') {
-        return 'linear-gradient(90deg, rgba(34, 197, 94, 0.00) 0%, rgba(34, 197, 94, 0.20) 100%), #2D3049';
+        return `linear-gradient(90deg, rgba(34, 197, 94, 0.00) 0%, rgba(34, 197, 94, 0.20) 100%), ${baseBackground}`;
       }
       if (voteType === 'no') {
-        return 'linear-gradient(90deg, rgba(239, 68, 68, 0.00) 0%, rgba(239, 68, 68, 0.20) 100%), #2D3049';
+        return `linear-gradient(90deg, rgba(239, 68, 68, 0.00) 0%, rgba(239, 68, 68, 0.20) 100%), ${baseBackground}`;
       }
-      return 'linear-gradient(90deg, rgba(148, 163, 184, 0.00) 0%, rgba(148, 163, 184, 0.15) 100%), #2D3049';
+      return `linear-gradient(90deg, rgba(148, 163, 184, 0.00) 0%, rgba(148, 163, 184, 0.15) 100%), ${baseBackground}`;
     };
 
     const getBorderColor = () => {
-      if (!isSelected) return '#2D3049';
+      if (!isSelected) return baseBackground;
       if (voteType === 'yes') return '#22c55e';
       if (voteType === 'no') return '#ef4444';
       return '#94a3b8';

--- a/src/components/vault-profile/VaultActivity.jsx
+++ b/src/components/vault-profile/VaultActivity.jsx
@@ -18,7 +18,6 @@ import clsx from 'clsx';
 import { useRouter } from '@tanstack/react-router';
 import toast from 'react-hot-toast';
 
-import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useVaultActivity } from '@/services/api/queries';
 import { Spinner } from '@/components/Spinner';
 import { Pagination } from '@/components/shared/Pagination';
@@ -608,21 +607,6 @@ export const VaultActivity = ({ vault }) => {
   return (
     <>
       <div className="flex flex-col gap-6">
-        <div className="flex flex-col items-center mb-6">
-          {vault.vaultImage ? (
-            <img
-              alt={vault.name}
-              className="w-[100px] h-[100px] rounded-full mb-4 object-cover border-4 border-steel-750"
-              src={vault.vaultImage}
-            />
-          ) : (
-            <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center border-4 border-steel-750">
-              <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
-            </div>
-          )}
-          <h1 className="text-3xl font-bold text-white">{vault.name}</h1>
-        </div>
-
         <div className="flex flex-col gap-6">
           <div className="flex flex-col gap-4">
             <div className="flex items-center justify-between">

--- a/src/components/vault-profile/VaultGovernance.jsx
+++ b/src/components/vault-profile/VaultGovernance.jsx
@@ -9,9 +9,11 @@ import {
   CircleArrowUp,
   ArrowLeft,
   Trash2,
+  PauseCircle,
 } from 'lucide-react';
 import { useQueryClient } from '@tanstack/react-query';
 import toast from 'react-hot-toast';
+import { useReadContract } from 'wagmi';
 
 import { ProposalInfo } from './ProposalInfo';
 import { ProposalEndDate } from './ProposalEndDate';
@@ -25,6 +27,7 @@ import { useDeleteProposal, useGovernanceProposals } from '@/services/api/querie
 import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder';
 import { useAuth } from '@/lib/auth/auth';
 import { useModalControls } from '@/lib/modals/modal.context';
+import { ChainType } from '@/utils/types';
 
 const PROPOSAL_TABS = ['All', 'Upcoming', 'Active', 'Rejected', 'Finished'];
 const PROPOSALS_PER_PAGE = 2;
@@ -39,6 +42,16 @@ export const VaultGovernance = ({ vault }) => {
 
   const queryClient = useQueryClient();
   const deleteProposalMutation = useDeleteProposal();
+
+  const isEvmVault = vault?.chainType === ChainType.ROBINHOOD;
+
+  // Read on-chain pause state for EVM vaults only.
+  const { data: isPaused } = useReadContract({
+    address: vault?.contractAddress,
+    abi: [{ type: 'function', stateMutability: 'view', name: 'paused', inputs: [], outputs: [{ type: 'bool' }] }],
+    functionName: 'paused',
+    query: { enabled: isEvmVault && !!vault?.contractAddress },
+  });
 
   const tabOptions = PROPOSAL_TABS.map(tab => ({
     value: tab,
@@ -208,6 +221,15 @@ export const VaultGovernance = ({ vault }) => {
         )}
         <h1 className="text-3xl font-bold">{vault.name}</h1>
       </div>
+
+      {isPaused && (
+        <div className="flex items-center gap-3 bg-yellow-500/10 border border-yellow-500/30 text-yellow-400 rounded-lg px-4 py-3 mb-6">
+          <PauseCircle className="w-5 h-5 shrink-0" />
+          <span className="text-sm font-medium">
+            This vault is currently paused. Contributions and new proposals are temporarily suspended.
+          </span>
+        </div>
+      )}
 
       {showProposalList ? (
         selectedProposal ? (

--- a/src/components/vault-profile/VaultGovernance.jsx
+++ b/src/components/vault-profile/VaultGovernance.jsx
@@ -22,7 +22,6 @@ import { LavaTabs } from '@/components/shared/LavaTabs';
 import { LavaSelect } from '@/components/shared/LavaSelect';
 import { HoverHelp } from '@/components/shared/HoverHelp';
 import { Pagination } from '@/components/shared/Pagination';
-import L4vaIcon from '@/components/shared/L4vaIcon';
 import { useDeleteProposal, useGovernanceProposals } from '@/services/api/queries';
 import { NoDataPlaceholder } from '@/components/shared/NoDataPlaceholder';
 import { useAuth } from '@/lib/auth/auth';
@@ -211,17 +210,6 @@ export const VaultGovernance = ({ vault }) => {
 
   return (
     <div className="text-white min-h-screen p-6 rounded-2xl overflow-hidden">
-      <div className="flex flex-col items-center mb-6">
-        {vault.vaultImage ? (
-          <img alt={vault.name} className="w-[100px] h-[100px] rounded-full mb-4 object-cover" src={vault.vaultImage} />
-        ) : (
-          <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center">
-            <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
-          </div>
-        )}
-        <h1 className="text-3xl font-bold">{vault.name}</h1>
-      </div>
-
       {isPaused && (
         <div className="flex items-center gap-3 bg-yellow-500/10 border border-yellow-500/30 text-yellow-400 rounded-lg px-4 py-3 mb-6">
           <PauseCircle className="w-5 h-5 shrink-0" />

--- a/src/components/vault-profile/VaultProfileView.jsx
+++ b/src/components/vault-profile/VaultProfileView.jsx
@@ -187,7 +187,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
 
   const { isAuthenticated, user } = useAuth();
   const { openModal } = useModalControls();
-  const { currencySymbol, pickByCurrency } = useCurrency();
+  const { currency, currencySymbol, pickByCurrency } = useCurrency();
 
   const [activeTab, setActiveTab] = useState(initialTab || 'Assets');
   const [deferredReady, setDeferredReady] = useState(false);
@@ -388,6 +388,27 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
     }
   };
 
+  const formatVaultStatCurrency = (value, maximumFractionDigits = 2) => {
+    if (value == null) return 'N/A';
+
+    const numericValue = Number(value);
+    if (Number.isNaN(numericValue)) return 'N/A';
+
+    const sign = numericValue < 0 ? '-' : '';
+    const absValue = Math.abs(numericValue);
+
+    // ETH values can be much smaller than ADA/USD-denominated values.
+    // Keep extra precision so non-zero values don't collapse to 0.
+    if (currency === 'eth') {
+      if (absValue > 0 && absValue < 0.000001) {
+        return `${sign}${currencySymbol}< 0.000001`;
+      }
+      return `${sign}${currencySymbol}${formatNum(absValue, 6)}`;
+    }
+
+    return `${sign}${currencySymbol}${formatNum(absValue, maximumFractionDigits)}`;
+  };
+
   // Calculate vault statistics - values computed on the backend in vault.vaultStats
   const vaultStats = {
     assetValue: vault.vaultStatus,
@@ -397,8 +418,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
         usd: vault.vaultStats?.ftGainsUsd,
         eth: vault.vaultStats?.ftGainsEth,
       });
-      if (val == null) return 'N/A';
-      return `${val < 0 ? '-' : ''}${currencySymbol}${formatNum(Math.abs(val))}`;
+      return formatVaultStatCurrency(val);
     })(),
     fdv: (() => {
       const val = pickByCurrency({
@@ -406,8 +426,7 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
         usd: vault.vaultStats?.fdvUsd,
         eth: vault.vaultStats?.fdvEth,
       });
-      if (val == null) return 'N/A';
-      return `${currencySymbol}${formatNum(val)}`;
+      return formatVaultStatCurrency(val);
     })(),
     fdvTvl: (() => {
       const val = vault.vaultStats?.fdvTvl;
@@ -421,17 +440,15 @@ export const VaultProfileView = ({ vault, activeTab: initialTab }) => {
         usd: vault.vaultStats?.vtPriceUsd,
         eth: vault.vaultStats?.vtPriceEth,
       });
-      if (val == null) return 'N/A';
-      return `${currencySymbol}${formatNum(val, 4)}`;
+      return formatVaultStatCurrency(val, 4);
     })(),
     tvl: (() => {
       const val = pickByCurrency({
-        ada: vault.vaultStats?.tvlAda,
-        usd: vault.vaultStats?.tvlUsd,
-        eth: vault.vaultStats?.tvlEth,
+        ada: vault.vaultStats?.tvlAda ?? vault.assetsPrices?.totalValueAda ?? vault.totalValueAda,
+        usd: vault.vaultStats?.tvlUsd ?? vault.assetsPrices?.totalValueUsd ?? vault.totalValueUsd,
+        eth: vault.vaultStats?.tvlEth ?? vault.assetsPrices?.totalValueEth ?? vault.totalValueEth,
       });
-      if (val == null) return 'N/A';
-      return `${currencySymbol}${formatNum(val)}`;
+      return formatVaultStatCurrency(val);
     })(),
   };
 

--- a/src/components/vault-profile/VaultSettings.jsx
+++ b/src/components/vault-profile/VaultSettings.jsx
@@ -8,7 +8,6 @@ import { useNavigate, useRouter } from '@tanstack/react-router';
 import { InfoRow } from '@/components/ui/infoRow';
 import { Accordion, AccordionContent, AccordionItem, AccordionTrigger } from '@/components/ui/accordion';
 import { Button } from '@/components/ui/button';
-import L4vaIcon from '@/components/shared/L4vaIcon';
 import { TokenImage } from '@/components/shared/TokenImage';
 import { useCurrency } from '@/hooks/useCurrency';
 import { useAuth } from '@/lib/auth/auth';
@@ -192,20 +191,6 @@ export const VaultSettings = ({ vault }) => {
   return (
     <>
       <div className="flex flex-col gap-4">
-        <div className="flex flex-col items-center mb-6">
-          {vault.vaultImage ? (
-            <img
-              alt={vault.name}
-              className="w-[100px] h-[100px] rounded-full mb-4 object-cover"
-              src={vault.vaultImage}
-            />
-          ) : (
-            <div className="w-[100px] h-[100px] rounded-full mb-4 bg-steel-850 flex items-center justify-center">
-              <L4vaIcon chainType={vault.chainType} className="h-8 w-8 text-white" />
-            </div>
-          )}
-          <h1 className="text-3xl font-bold">{vault.name}</h1>
-        </div>
         <div className="bg-steel-750 rounded-lg p-4">
           <div className="space-y-2">
             <h2 className="text-2xl font-bold mb-4">Vault Info</h2>

--- a/src/lib/evm/vaultFactory.abi.ts
+++ b/src/lib/evm/vaultFactory.abi.ts
@@ -1,16 +1,9 @@
 /**
- * Minimal V3 ABI for VaultFactory — only the createVault function.
- * Full contract ABI is not needed on the frontend.
+ * Minimal V4 ABI for VaultFactory — only the createVault function.
  *
- * Mirrors the Solidity V3 signature:
- *   createVault(VaultConfig cfg, uint256 adminNonce, uint256 deadline, bytes adminSignature)
- *     returns (address vault, address vaultToken)
- *
- * V3 removes all rate tables from CycleConfig — final VT / native
- * allocations are committed off-chain and published on-chain as a Merkle
- * root at Vault.closeCycle(...). If the contract is ever upgraded, this
- * ABI must be kept in sync with `src/libraries/VaultTypes.sol` in the
- * `vault-contract-solidity` repo.
+ * V4 VaultConfig adds archetype (bytes32), vaultDeployer (address),
+ * creationApprover (address), and authority (address); the V3 `admin`
+ * field is gone. Keep in sync with VaultTypes.sol in vault-contract-solidity.
  */
 export const VAULT_FACTORY_ABI = [
   {
@@ -23,8 +16,11 @@ export const VAULT_FACTORY_ABI = [
         type: 'tuple',
         components: [
           { name: 'vaultId', type: 'bytes32' },
+          { name: 'archetype', type: 'bytes32' },
+          { name: 'vaultDeployer', type: 'address' },
           { name: 'creator', type: 'address' },
-          { name: 'admin', type: 'address' },
+          { name: 'creationApprover', type: 'address' },
+          { name: 'authority', type: 'address' },
           { name: 'mintingKey', type: 'address' },
           { name: 'treasury', type: 'address' },
           { name: 'vtName', type: 'string' },


### PR DESCRIPTION
This pull request introduces support for EVM-based vaults (specifically Robinhood Chain) in the proposal creation modals, with tailored UI, data handling, and logic for EVM assets and actions. The changes ensure that proposal flows, asset selections, and market price explanations are accurate and user-friendly for both Cardano and EVM vaults.

**EVM Vault Support and UI/UX Adjustments:**

* Added detection of EVM vaults using `chainType`, and introduced separate execution option lists for Cardano and EVM vaults in `CreateProposalModal.jsx`. UI elements and labels now reflect the correct blockchain context, including wallet connection prompts and asset labels. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R36-R38) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R50-R65) [[3]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R79-R87) [[4]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L97-R113) [[5]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L150-R172)

* Updated asset selection in the expansion proposal modal: Cardano vaults use policy ID multi-select, while EVM vaults use contract address selection. Data is now separated into `expansionPolicyIds` (Cardano) and `expansionEvmAssets` (EVM), with validation and onChange handling updated accordingly. [[1]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR9-R22) [[2]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR31-R66) [[3]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aL61-R91) [[4]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aL86-R126) [[5]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR143)

**Proposal Data Handling and Submission Logic:**

* Modified proposal payload construction to include EVM-specific fields for expansion and marketplace actions, including support for Uniswap swaps and closing positions. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R192-R196) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L199-R249)

* Improved wallet connection checks and error messages to distinguish between Cardano and Robinhood/EVM wallets. Payment signing logic now ensures the correct wallet type is present. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R79-R87) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L150-R172) [[3]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R311-R314)

**Market Price and Example Calculation Explanations:**

* Updated market price explanations and calculation examples in the Acquire Expansion modal to clarify the source of pricing (Uniswap for EVM, DEXes for Cardano) and dynamically adjust example amounts and labels based on vault type. [[1]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8R10-R15) [[2]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8L218-R222) [[3]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8L239-R274)

**General Refactoring and Bug Fixes:**

* Refactored option lists and selection logic to use the correct set of execution options based on vault type, fixing bugs where Cardano-only options could appear for EVM vaults and vice versa. [[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L349-R403) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L454-R508) [[3]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R534)

---

**References:**  
[[1]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R36-R38) [[2]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R50-R65) [[3]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R79-R87) [[4]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L97-R113) [[5]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L150-R172) [[6]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR9-R22) [[7]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR31-R66) [[8]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aL61-R91) [[9]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aL86-R126) [[10]](diffhunk://#diff-6d4ee9cb36ae50b0ecd20e716b2dc335d61b87774a96200155395d05af79f52aR143) [[11]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R192-R196) [[12]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L199-R249) [[13]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R311-R314) [[14]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8R10-R15) [[15]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8L218-R222) [[16]](diffhunk://#diff-1e731eda0189210dae12acedea73a790def66e4dd4f58d28358c74329fb063a8L239-R274) [[17]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L349-R403) [[18]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4L454-R508) [[19]](diffhunk://#diff-99bc566b53c3148a90df0220d29ae77733ba4be103478e5dab45c16041e104d4R534)